### PR TITLE
[12.0][IMP] sale_product_pack add pack_modifiable in the sale order line.

### DIFF
--- a/sale_product_pack/models/product_pack_line.py
+++ b/sale_product_pack/models/product_pack_line.py
@@ -22,6 +22,7 @@ class ProductPack(models.Model):
             'pack_parent_line_id': line.id,
             'pack_depth': line.pack_depth + 1,
             'company_id': order.company_id.id,
+            'pack_modifiable': line.product_id.pack_modifiable,
         }
         sol = line.new(line_vals)
         sol.product_id_change()

--- a/sale_product_pack/models/sale_order_line.py
+++ b/sale_product_pack/models/sale_order_line.py
@@ -30,6 +30,8 @@ class SaleOrderLine(models.Model):
         'pack_parent_line_id',
         'Lines in pack'
     )
+    pack_modifiable = fields.Boolean(
+        help='The parent pack is modifiable')
 
     @api.multi
     def expand_pack_line(self, write=False):
@@ -88,7 +90,18 @@ class SaleOrderLine(models.Model):
         """ Do not let to edit a sale order line if this one belongs to pack
         """
         if self._origin.pack_parent_line_id and \
-           not self._origin.pack_parent_line_id.product_id.pack_modifiable:
+           not self._origin.pack_modifiable:
             raise UserError(_(
                 'You can not change this line because is part of a pack'
                 ' included in this order'))
+
+    @api.multi
+    def action_open_parent_pack_product_view(self):
+        domain = [('id', 'in', self.mapped(
+            'pack_parent_line_id').mapped('product_id').ids)]
+        return {'name': _('Parent Product'),
+                'type': 'ir.actions.act_window',
+                'res_model': 'product.product',
+                'view_type': 'form',
+                'view_mode': 'tree,form',
+                'domain': domain}

--- a/sale_product_pack/readme/CONTRIBUTORS.rst
+++ b/sale_product_pack/readme/CONTRIBUTORS.rst
@@ -2,3 +2,7 @@
 
   * Ernesto Tejeda
   * Pedro M. Baeza
+
+* `Akretion <https://akretion.com>`_:
+
+  * Raphaël Reverdy

--- a/sale_product_pack/views/product_pack_line_views.xml
+++ b/sale_product_pack/views/product_pack_line_views.xml
@@ -24,4 +24,21 @@
             </field>
         </field>
     </record>
+
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">
+                <field name="pack_modifiable" invisible="True" />
+                <field name="pack_parent_line_id" invisible="True" />
+                <button string="Parent Pack is not modifiable"
+                    name="action_open_parent_pack_product_view"
+                    type="object"
+                    attrs="{'invisible': ['|', ('pack_parent_line_id', '=', False), ('pack_modifiable', '=', True)]}"
+                    icon="fa-lock"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
It's helpfull to know directly if the sale order line is editable.

If the sale order is edited from an api, onchange are not always triggered
so having this field helps to raise an error.

And it can be used to display in the view that the line is not editable.