### PR TITLE
[FIX] fixes mysterious CacheMiss errors

### DIFF
--- a/product_pack/models/product_product.py
+++ b/product_pack/models/product_product.py
@@ -87,7 +87,6 @@ class ProductProduct(models.Model):
     @api.depends('list_price', 'price_extra')
     def _compute_product_lst_price(self):
         packs, no_packs = self.split_pack_products()
-        super(ProductProduct, no_packs)._compute_product_lst_price()
         to_uom = None
         if 'uom' in self._context:
             to_uom = self.env['uom.uom'].browse([self._context['uom']])
@@ -97,3 +96,4 @@ class ProductProduct(models.Model):
                 list_price = product.uom_id._compute_price(
                     list_price, to_uom)
             product.lst_price = list_price + product.price_extra
+        super(ProductProduct, no_packs)._compute_product_lst_price()


### PR DESCRIPTION
I've got some CacheMiss Errors using product_pack module while additionally using sale.order.template.

Steps were:
1) creating a new Order with a Template
2) deleting all predefined Lines
3) Searching for a new product
4) CacheMiss Error happens at search

So while debugging i found that changing the time when the super call would happen somehow fixed the issue.

I don't see any problems with changing the super call position so if anyone else might run into the same problem this PR might fix it for them too.