### PR TITLE
[12.0] [FIX] product_pack : use sudo in the get_pack_lines method

### DIFF
--- a/product_pack/models/product_product.py
+++ b/product_pack/models/product_product.py
@@ -47,7 +47,7 @@ class ProductProduct(models.Model):
                 lambda p: p.pack_ok and p.pack_type == 'detailed'
                 and p.pack_component_price == 'detailed')
 
-        no_packs = (self | self.get_pack_lines().mapped('product_id')) - packs
+        no_packs = (self | self.sudo().get_pack_lines().mapped('product_id')) - packs
         return packs, no_packs
 
     @api.multi


### PR DESCRIPTION
This is because in the e-commerce when an user portal or public try to access to the catalog of products has an access error to the model "product pack line".
 Them problem is when the method price_compute is call then try to compute the products expand the product pack and try to access to that model.
This way evoid to set an access  read to "product pack line" for the portal and public users.