### PR TITLE
[FIX] product_pack: Use price already calculated to the childs.

### DIFF
--- a/product_pack/models/product_product.py
+++ b/product_pack/models/product_product.py
@@ -60,7 +60,7 @@ class ProductProduct(models.Model):
         for product in packs.with_context(prefetch_fields=False):
             pack_price = 0.0
             for pack_line in product.pack_line_ids:
-                pack_price += pack_line.get_price()
+                pack_price += prices[pack_line.product_id.id] * pack_line.quantity
             pricelist_id_or_name = self._context.get("pricelist")
             # if there is a pricelist on the context the returned prices are on
             # that currency but, if the pack product has a different currency


### PR DESCRIPTION
For the case, that we need to ensure the values are completed calculated, the price for the non pack products are in the dict of "prices" and we need to use them instead to take from "Price" that in some case is zero.