### PR TITLE
[13.0] [FIX] product_pack: Use sudo when calculate the price and the user doesn't have access to write in the model product_product.

### DIFF
--- a/product_pack/models/product_product.py
+++ b/product_pack/models/product_product.py
@@ -98,7 +98,7 @@ class ProductProduct(models.Model):
         to_uom = None
         if "uom" in self._context:
             to_uom = self.env["uom.uom"].browse([self._context["uom"]])
-        for product in packs:
+        for product in packs.sudo():
             list_price = product.price_compute("list_price").get(product.id)
             if to_uom:
                 list_price = product.uom_id._compute_price(list_price, to_uom)


### PR DESCRIPTION
Step to reproduce the issue:

Configuration to replicate the scenario with the bug:
 Select  a user without any administration rights, either sales, invoice or accounting. I use the "demo" user in runbot to replicate.

1) In the list view, if we search in the bar for the name of some product pack, an error appears.

The error is like that:

```
Sorry, you are not allowed to modify documents of type 'Product' (product.product). This operation is allowed for the groups:
	- Administration/Settings
	- Inventory/Administrator
	- Invoicing/Billing Administrator
	- Sales/Administrator - (Operation: write, User: 6)
```

This also happens when add a product in the sale line.