### PR TITLE
[FIX] product_pack: Solve the problem with the packs and the user without right to write in products.

### DIFF
--- a/product_pack/models/product_product.py
+++ b/product_pack/models/product_product.py
@@ -49,8 +49,7 @@ class ProductProduct(models.Model):
                 and p.pack_component_price == "detailed"
             )
 
-        no_packs = (self | self.sudo().get_pack_lines().mapped("product_id")) - packs
-        return packs, no_packs
+        return packs, (self - packs)
 
     def price_compute(self, price_type, uom=False, currency=False, company=False):
         packs, no_packs = self.split_pack_products()
@@ -98,7 +97,7 @@ class ProductProduct(models.Model):
         to_uom = None
         if "uom" in self._context:
             to_uom = self.env["uom.uom"].browse([self._context["uom"]])
-        for product in packs.sudo():
+        for product in packs:
             list_price = product.price_compute("list_price").get(product.id)
             if to_uom:
                 list_price = product.uom_id._compute_price(list_price, to_uom)


### PR DESCRIPTION
This solve the problem when with a user without rights to write in product, you want to search or access to a product variant who are a pack regardless the type or the composition of that one.

We undone this PR https://github.com/OCA/product-pack/pull/42 because not solve completly the problem, with this change now all problems are solved.