### PR TITLE
[ADD] sale_stock_product_pack: New  glue module

### DIFF
--- a/sale_stock_product_pack/__init__.py
+++ b/sale_stock_product_pack/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_stock_product_pack/__manifest__.py
+++ b/sale_stock_product_pack/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Sale Stock Product Pack",
+    "summary": "Compatibility module for packs that are storable products",
+    "version": "13.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Sale",
+    "website": "https://github.com/OCA/product-pack.git",
+    "author": "Tecnativa, Odoo Community Association (OCA)",
+    "maintainers": ["chienandalu"],
+    "license": "AGPL-3",
+    "depends": ["sale_product_pack", "stock_product_pack"],
+    "data": [],
+}

--- a/sale_stock_product_pack/models/__init__.py
+++ b/sale_stock_product_pack/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_stock_product_pack/models/sale_order.py
+++ b/sale_stock_product_pack/models/sale_order.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _compute_qty_delivered(self):
+        """Compute pack delivered pack quantites according to its components
+        deliveries"""
+        super()._compute_qty_delivered()
+        main_pack_lines = self.filtered("pack_parent_line_id").mapped(
+            "pack_parent_line_id"
+        )
+        for line in main_pack_lines.filtered(
+            lambda x: x.qty_delivered_method == "stock_move"
+            and x.pack_child_line_ids
+            and x.product_uom_qty
+        ):
+            delivered_packs = []
+            # We filter non qty lines of editable packs
+            for pack_line in line.pack_child_line_ids.filtered("product_uom_qty"):
+                # If a component isn't delivered, the pack isn't as well
+                if not pack_line.qty_delivered:
+                    delivered_packs.append(0)
+                    break
+                qty_per_pack = pack_line.product_uom_qty / line.product_uom_qty
+                delivered_packs.append(pack_line.qty_delivered / qty_per_pack)
+            line.qty_delivered = min(delivered_packs)

--- a/sale_stock_product_pack/readme/CONTRIBUTORS.rst
+++ b/sale_stock_product_pack/readme/CONTRIBUTORS.rst
@@ -1,0 +1,4 @@
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Ernesto Tejeda
+  * Pedro M. Baeza

--- a/sale_stock_product_pack/readme/DESCRIPTION.rst
+++ b/sale_stock_product_pack/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This modules adds compatibility of product packs with sales and stock altogether:
+
+- Correctly compute delivered quantities for the different types of packs so they
+  can be properly invoiced when the pack is storable.

--- a/sale_stock_product_pack/readme/ROADMAP.rst
+++ b/sale_stock_product_pack/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+* Non detailed packs aren't yet supported by stock_product_pack, so no support for them
+  either in this module.

--- a/sale_stock_product_pack/tests/__init__.py
+++ b/sale_stock_product_pack/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_stock_product_pack

--- a/sale_stock_product_pack/tests/test_sale_stock_product_pack.py
+++ b/sale_stock_product_pack/tests/test_sale_stock_product_pack.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tests import Form, common
+
+
+class TestSaleStockProductPack(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product_pack = cls.env.ref(
+            "product_pack.product_pack_cpu_detailed_components"
+        )
+        cls.product_pack.type = "product"
+        cls.product_pack.invoice_policy = "delivery"
+        cls.product_pack.pack_line_ids.product_id.invoice_policy = "delivery"
+        sale_form = Form(cls.env["sale.order"])
+        sale_form.partner_id = cls.env["res.partner"].create({"name": "Mr. Odoo"})
+        with sale_form.order_line.new() as line:
+            line.product_id = cls.product_pack
+            line.product_uom_qty = 9
+        cls.sale = sale_form.save()
+        cls.sale.action_confirm()
+
+    def test_delivered_quantities(self):
+        pack_line = self.sale.order_line.filtered(
+            lambda x: x.product_id == self.product_pack
+        )
+        self.assertEqual(0, pack_line.qty_delivered)
+        # Process the picking
+        for line in self.sale.picking_ids.move_lines.filtered(
+            lambda x: x.product_id != self.product_pack
+        ):
+            line.quantity_done = line.product_uom_qty
+        self.sale.picking_ids.action_done()
+        # All components delivered, all the pack quantities should be so
+        # TODO: it needs to compute twice. In view it does it fine.
+        self.sale.order_line.mapped("qty_delivered")
+        self.assertEqual(9, pack_line.qty_delivered)

--- a/setup/sale_stock_product_pack/odoo/addons/sale_stock_product_pack
+++ b/setup/sale_stock_product_pack/odoo/addons/sale_stock_product_pack
@@ -1,0 +1,1 @@
+../../../../sale_stock_product_pack

--- a/setup/sale_stock_product_pack/setup.py
+++ b/setup/sale_stock_product_pack/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This modules adds compatibility of product packs with sales and stock altogether:

- Correctly compute delivered quantities for the different types of packs so they
  can be properly invoiced when the pack is storable.

cc @Tecnativa TT31038