### PR TITLE
[13.0] [FIX] sale_stock_product_pack: avoid error when the cancel quantity for all components.

### DIFF
--- a/sale_stock_product_pack/models/sale_order.py
+++ b/sale_stock_product_pack/models/sale_order.py
@@ -27,4 +27,4 @@ class SaleOrderLine(models.Model):
                     break
                 qty_per_pack = pack_line.product_uom_qty / line.product_uom_qty
                 delivered_packs.append(pack_line.qty_delivered / qty_per_pack)
-            line.qty_delivered = min(delivered_packs)
+            line.qty_delivered = delivered_packs and min(delivered_packs) or 0.0


### PR DESCRIPTION
In case you cancel the quantity for all components of the pack an error occurred, after this change we set the quantity delivery to zero.