### PR TITLE
[13.0][FIX] stock_product_pack: Remove unnecessary and wrong action from tests

### DIFF
--- a/stock_product_pack/tests/test_stock_product_pack.py
+++ b/stock_product_pack/tests/test_stock_product_pack.py
@@ -147,7 +147,6 @@ class TestSaleProductPack(SavepointCase):
             self.env.ref("stock.stock_location_stock"),
             pg,
         )
-        self.env["stock.scheduler.compute"].create({}).procure_calculation()
         picking_ids = self.env["stock.picking"].search([("group_id", "=", pg.id)])
         # we need to ensure that only the compents of the packs are in the moves.
         self.assertFalse(self.pack_dc_with_dm in picking_ids.move_lines.product_id)


### PR DESCRIPTION
The `stock.scheduler.compute` wizard action is run in a different Thread that the main one.
In a test environment, that is problematic, as the test thread ends without actually getting the result from the 2nd that is launched.
This can lead to unclosed cursors and an inconsistent state in the environment.
Besides, for the same reason, we can simply delete the step from the test, as it was not doing anything.

@Tecnativa
TT32016

ping @pedrobaeza 