### PR TITLE
[FIX] website_sale_product_pack: Fix product pack detailed price on e-commerce.

### DIFF
--- a/website_sale_product_pack/models/__init__.py
+++ b/website_sale_product_pack/models/__init__.py
@@ -1,2 +1,3 @@
+from . import product_template
 from . import sale_order
 from . import website

--- a/website_sale_product_pack/models/product_template.py
+++ b/website_sale_product_pack/models/product_template.py
@@ -1,0 +1,27 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    def _get_combination_info(
+        self,
+        combination=False,
+        product_id=False,
+        add_qty=1,
+        pricelist=False,
+        parent_combination=False,
+        only_template=False,
+    ):
+        if self.pack_ok:
+            self = self.with_context(whole_pack_price=True)
+        return super()._get_combination_info(
+            combination=combination,
+            product_id=product_id,
+            add_qty=add_qty,
+            pricelist=pricelist,
+            parent_combination=parent_combination,
+            only_template=only_template,
+        )


### PR DESCRIPTION
For a product pack with detailed prices, in the shop the price that shows is not sum of the component as the configuration that the pack has, instead of this is taken the price of product. When you selected to checkout the price will correct to the real value.