### PR TITLE
[13.0] [FIX] website_sale_product_pack: Fixed duplicated reward line image in cart summary

### DIFF
--- a/website_sale_product_pack/views/templates.xml
+++ b/website_sale_product_pack/views/templates.xml
@@ -82,7 +82,7 @@
             expr="//span[@t-field='line.product_id.image_128']"
             position="attributes"
         >
-            <attribute name="t-if">not line.pack_parent_line_id</attribute>
+            <attribute name="t-if">not line.pack_parent_line_id and not line.is_reward_line or not line.sudo().product_id.image_128</attribute>
         </xpath>
         <xpath expr="//strong[@t-field='line.name_short']" position="attributes">
             <attribute name="t-if">not line.pack_parent_line_id</attribute>


### PR DESCRIPTION
For reward lines the image of the product in the cart summary appears two times.