### PR TITLE
[13.0][FIX] price is shown in view instead of list_price (which the original view shows)

### DIFF
--- a/website_sale_product_pack/views/templates.xml
+++ b/website_sale_product_pack/views/templates.xml
@@ -54,7 +54,7 @@
             <t
                 t-set="list_price_converted"
                 t-if="line.pack_child_line_ids"
-                t-value="website.currency_id._convert(combination_info['price'], website_sale_order.currency_id, website_sale_order.company_id, date)"
+                t-value="website.currency_id._convert(combination_info['list_price'], website_sale_order.currency_id, website_sale_order.company_id, date)"
             />
         </xpath>
         <xpath expr="//strong[@t-field='line.name_short']" position="attributes">


### PR DESCRIPTION
We detected that not the correct price was being shown in the website and we realized the inherited view replace the field list_price for the field price, which is not correct.