### PR TITLE
[14.0][IMP] sale_product_pack: Set Unit Price to zero for product pack on sale order line when…

### DIFF
--- a/sale_product_pack/models/sale_order_line.py
+++ b/sale_product_pack/models/sale_order_line.py
@@ -52,6 +52,8 @@ class SaleOrderLine(models.Model):
         # only want to update prices
         vals_list = []
         if self.product_id.pack_ok and self.pack_type == "detailed":
+            if self.pack_component_price == "detailed":
+                self.price_unit = 0
             for subline in self.product_id.get_pack_lines():
                 vals = subline.get_sale_order_line_vals(self, self.order_id)
                 if write:

--- a/sale_product_pack/tests/test_sale_product_pack.py
+++ b/sale_product_pack/tests/test_sale_product_pack.py
@@ -63,6 +63,8 @@ class TestSaleProductPack(SavepointCase):
             [sequence, sequence, sequence, sequence],
             self.sale_order.order_line.mapped("sequence"),
         )
+        # The price of the product pack line is zero
+        self.assertAlmostEqual(pack_line.price_subtotal, 0.0)
         # The products of those four lines are the main product pack and its
         # product components
         self.assertEqual(


### PR DESCRIPTION
… pack component price is detailled
Steps to reproduce : 
- set up a product pack with a price of 1000 EUR tax included : detailed pack type & detailed component price
- set up 2 components products with different tax rates : 
    - 500 EUR 5% tax included
    - 500 EUR 10% tax included
- make a quotation with the product pack and save it

wrong behavior : the total of the sale order is 2000 EUR (each line shows the product price)
right behavior : the total of the sale order should be 1000 EUR (the product pack price should be zero)