### PR TITLE
[IMP] stock_product_pack: incoming/outgoing stock

### DIFF
--- a/stock_product_pack/models/product_product.py
+++ b/stock_product_pack/models/product_product.py
@@ -17,39 +17,72 @@ class ProductProduct(models.Model):
             lot_id, owner_id, package_id, from_date=from_date, to_date=to_date
         )
         packs = self.filtered("pack_ok")
+
+        def pack_quantity(components):
+            """ Returns the number of packs that can be assembled with the stock of
+                the components.
+                :param components: List of tuples (stock, quantity required for pack)
+            """
+            return (
+                components
+                and min(
+                    [math.floor(stock / quantity) for stock, quantity in components]
+                )
+                or 0
+            )
+
         for product in packs.with_context(prefetch_fields=False):
-            pack_qty_available = []
-            pack_virtual_available = []
+            sub_available = []
+            sub_available_incoming = []
+            sub_available_ongoing = []
             pack_free_qty = []
             subproducts = product.pack_line_ids.filtered(
                 lambda p: p.product_id.type == "product"
             )
-            for subproduct in subproducts:
+            for subproduct in subproducts.filtered(lambda s: s.quantity):
                 subproduct_stock = subproduct.product_id
                 sub_qty = subproduct.quantity
-                if sub_qty:
-                    s_qty_available = res.get(subproduct_stock.id, {}).get(
-                        "qty_available", subproduct_stock.qty_available
-                    )
-                    pack_qty_available.append(math.floor(s_qty_available / sub_qty))
-                    s_virtual_available = res.get(subproduct_stock.id, {}).get(
-                        "virtual_available", subproduct_stock.virtual_available
-                    )
-                    pack_virtual_available.append(
-                        math.floor(s_virtual_available / sub_qty)
-                    )
-                    s_free_qty = res.get(subproduct_stock.id, {}).get(
-                        "free_qty", subproduct_stock.free_qty
-                    )
-                    pack_free_qty.append(math.floor(s_free_qty / sub_qty))
+                s_qty_available = res.get(subproduct_stock.id, {}).get(
+                    "qty_available", subproduct_stock.qty_available
+                )
+                s_incoming_qty = res.get(subproduct_stock.id, {}).get(
+                    "incoming_qty", subproduct_stock.incoming_qty
+                )
+                s_outgoing_qty = res.get(subproduct_stock.id, {}).get(
+                    "outgoing_qty", subproduct_stock.outgoing_qty
+                )
+                s_free_qty = res.get(subproduct_stock.id, {}).get(
+                    "free_qty", subproduct_stock.free_qty
+                )
+                sub_available.append((s_qty_available, sub_qty))
+                sub_available_incoming.append(
+                    (s_qty_available + s_incoming_qty, sub_qty)
+                )
+                sub_available_ongoing.append(
+                    (s_qty_available - s_outgoing_qty, sub_qty)
+                )
+                pack_free_qty.append((s_free_qty, sub_qty))
+
+            # The number of packs that can be assembled with the stock on hand.
+            pack_qty_available = pack_quantity(sub_available)
+            # The number of extra packs that I will be able to assemble
+            # if arrives the incoming stock.
+            pack_incoming_qty = (
+                pack_quantity(sub_available_incoming) - pack_qty_available
+            )
+            # The number of packs that I will NOT be able to assemble
+            # if the outgoing stock is delivered.
+            pack_outgoing_qty = pack_qty_available - pack_quantity(
+                sub_available_ongoing
+            )
             res[product.id] = {
-                "qty_available": (pack_qty_available and min(pack_qty_available) or 0),
-                "free_qty": (pack_free_qty and min(pack_free_qty) or 0),
-                "incoming_qty": 0,
-                "outgoing_qty": 0,
-                "virtual_available": (
-                    pack_virtual_available and min(pack_virtual_available) or 0
-                ),
+                "qty_available": pack_qty_available,
+                "incoming_qty": pack_incoming_qty,
+                "outgoing_qty": pack_outgoing_qty,
+                "virtual_available": pack_qty_available
+                + pack_incoming_qty
+                - pack_outgoing_qty,
+                "free_qty": pack_quantity(pack_free_qty),
             }
         return res
 


### PR DESCRIPTION
Before this commit, the module do not compute the incoming and outgoing pack stock.
Now is done following this logic:

- _Stock_on_hand_ = The number of packs that can be assembled with the stock components on hand.
- _Stock_on_hand_inc_ = The number of packs that can be assembled with the stock components on hand plus the incoming stock.
- Stock_on_hand_out = The number of packs that can be assembled with the stock components on hand minus the outgoing stock.

Then:

**Stock incoming** = _Stock_on_hand_inc_ - _Stock_on_hand_
This is the number of extra packs that we will be able to assemble if the incoming stock of the components arrives.

**Stock outgoing** = _Stock_on_hand_ + _Stock_on_hand_out_
This is the number of packs that we will NOT be able to assemble if the outgoing stock of the components is delivered

**Stock virtual available** = available + incoming - outgoing
Note that this is an improvement because now we are following the same logic for virtual stock as Odoo in normal products.