### PR TITLE
[13.0][FIX] product_pack: Compute directly the price on pricelists

### DIFF
--- a/product_pack/models/__init__.py
+++ b/product_pack/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import product_pack_line
+from . import product_pricelist
 from . import product_product
 from . import product_template

--- a/product_pack/models/product_pricelist.py
+++ b/product_pack/models/product_pricelist.py
@@ -1,0 +1,29 @@
+# Copyright 2022 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class ProductPricelist(models.Model):
+    _inherit = "product.pricelist"
+
+    def _compute_price_rule(self, products_qty_partner, date=False, uom_id=False):
+        """Don't call super when dealing with detailed and non detailed packs,
+        as the computations done after calling `price_compute` modify the final returned
+        price, so we compute it directly in these cases.
+        """
+        products_qty_partner_super = [
+            (s[0], s[1], s[2])
+            for s in products_qty_partner
+            if not s[0] in s[0].split_pack_products()[0]
+        ]
+        res = super()._compute_price_rule(
+            products_qty_partner_super, date=date, uom_id=uom_id
+        )
+        for product, _, _ in products_qty_partner:
+            if product in product.split_pack_products()[0]:
+                res[product.id] = (
+                    product.price_compute("list_price")[product.id],
+                    False,
+                )
+        return res

--- a/product_pack/models/product_product.py
+++ b/product_pack/models/product_product.py
@@ -27,24 +27,7 @@ class ProductProduct(models.Model):
         return self.mapped("pack_line_ids")
 
     def split_pack_products(self):
-        """Split products and the pack in 2 separate recordsets.
-
-        :return: [packs, no_packs]
-        """
-        packs = self.filtered(
-            lambda p: p.pack_ok
-            and (
-                (p.pack_type == "detailed" and p.pack_component_price == "totalized")
-                or p.pack_type == "non_detailed"
-            )
-        )
-        # We could need to check the price of the whole pack (e.g.: e-commerce)
-        if self.env.context.get("whole_pack_price"):
-            packs |= self.filtered(
-                lambda p: p.pack_ok
-                and p.pack_type == "detailed"
-                and p.pack_component_price == "detailed"
-            )
+        packs = self.filtered(lambda p: p.product_tmpl_id._is_pack_to_be_handled())
         return packs, (self - packs)
 
     def price_compute(self, price_type, uom=False, currency=False, company=False):


### PR DESCRIPTION
Steps to reproduce the problem:

- Create a new pack with "Pack component price" = "Totalized in main product"
- Put some components on it.
- Create a sales order with such pack.
- The price unit got in the sales order line is not the sum of the components.

That's because the computations done after calling `price_compute` in the pricelist engine modify the final returned price, so we don't call super on such cases and compute it directly.

@Tecnativa TT37977