### PR TITLE
[13.0][FIX] website_sale_product_pack: detailed totalized packs

### DIFF
--- a/website_sale_product_pack/models/sale_order.py
+++ b/website_sale_product_pack/models/sale_order.py
@@ -9,11 +9,22 @@ class SaleOrder(models.Model):
     def _cart_update(
         self, product_id=None, line_id=None, add_qty=0, set_qty=0, **kwargs
     ):
-        """We need to keep the discount defined on the components when checking out"""
+        """We need to keep the discount defined on the components when checking out.
+        Also when a line comes from a totalized pack, we should flag it to avoid
+        changing it's price in a cart step."""
         line = self.env["sale.order.line"].browse(line_id)
         if line and line.pack_parent_line_id:
+            pack = line.pack_parent_line_id.product_id
+            detailed_totalized_pack = (
+                pack.pack_type == "detailed"
+                and pack.pack_component_price in {"totalized", "ignored"}
+            )
             return super(
-                SaleOrder, self.with_context(pack_discount=line.discount)
+                SaleOrder,
+                self.with_context(
+                    pack_discount=line.discount,
+                    detailed_totalized_pack=detailed_totalized_pack,
+                ),
             )._cart_update(product_id, line_id, add_qty, set_qty, **kwargs)
         return super()._cart_update(product_id, line_id, add_qty, set_qty, **kwargs)
 
@@ -32,10 +43,14 @@ class SaleOrder(models.Model):
 
     def _website_product_id_change(self, order_id, product_id, qty=0):
         """In the final checkout step, we could miss the component discount as the
-        product prices are recomputed"""
+        product prices are recomputed. We should also consider a forced price
+        recomputation that would set a price on our detailed totalized pack lines
+        duplicating the total price"""
         res = super()._website_product_id_change(order_id, product_id, qty=qty)
         if self.env.context.get("pack_discount"):
             res["discount"] = self.env.context.get("pack_discount")
+        if self.env.context.get("detailed_totalized_pack"):
+            res["price_unit"] = 0
         return res
 
 


### PR DESCRIPTION
When the cart is confirmed, a price recalculation is triggered for every order line. This is wrong for detailed totalized packs, which lines should be at 0.

cc @Tecnativa TT38186

please review @pedrobaeza @ernestotejeda 