### PR TITLE
[12.0][FIX] Avoid pack_modifiable field inconsistencies on product variant modifications

### DIFF
--- a/product_pack/README.rst
+++ b/product_pack/README.rst
@@ -110,6 +110,9 @@ Contributors
   * Pedro M. Baeza
   * Jairo Llopis
   * Sergio Teruel
+* `Trey <https://www.trey.es>`_:
+
+  * Miguel Poyatos <miguel@trey.es>
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_pack/models/product_product.py
+++ b/product_pack/models/product_product.py
@@ -97,3 +97,7 @@ class ProductProduct(models.Model):
                 list_price = product.uom_id._compute_price(
                     list_price, to_uom)
             product.lst_price = list_price + product.price_extra
+
+    @api.onchange('pack_type', 'pack_component_price')
+    def onchange_pack_type(self):
+        self.mapped('product_tmpl_id').onchange_pack_type()


### PR DESCRIPTION
We call template onchange to avoid pack_modifiable field inconsistencies on product variant modifications.