### PR TITLE
[FIX] product_pack: compute price pack detailed totalized

### DIFF
--- a/product_pack/models/__init__.py
+++ b/product_pack/models/__init__.py
@@ -3,3 +3,4 @@
 from . import product_pack_line
 from . import product_product
 from . import product_template
+from . import product_pricelist

--- a/product_pack/models/product_pricelist.py
+++ b/product_pack/models/product_pricelist.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class Pricelist(models.Model):
+    _inherit = "product.pricelist"
+
+    def _compute_price_rule(self, products_qty_partner, date=False, uom_id=False):
+        product = products_qty_partner[0][0]
+        res = {}
+        if (
+            product.pack_ok
+            and product.pack_type == "detailed"
+            and product.pack_component_price == "totalized"
+        ):
+            res[product.id] = (product.price_compute("list_price")[product.id], False)
+            return res
+        else:
+            return super()._compute_price_rule(
+                products_qty_partner, date=date, uom_id=uom_id
+            )


### PR DESCRIPTION
For sale orders that have a Pack (detailed and totalized in main product) and the pricelist has an operation (i.e. list_price + 10%), the result was wrong, adding +10% twice.
In this PR, we only calculate the price with pricelist for the components of the pack and not for the pack