### PR TITLE
[14.0][IMP][sale_product_pack] Add prices in Product pack lines

### DIFF
--- a/sale_product_pack/models/product_pack_line.py
+++ b/sale_product_pack/models/product_pack_line.py
@@ -10,6 +10,25 @@ class ProductPack(models.Model):
         "Sale discount (%)",
         digits="Discount",
     )
+    total_lst_price = fields.Float(
+        "Total Public Price",
+        digits="Product Price",
+        compute="_compute_total_price",
+    )
+    total_standard_price = fields.Float(
+        "Total Cost Price",
+        digits="Product Price",
+        compute="_compute_total_price",
+    )
+
+    def _compute_total_price(self):
+        for line in self:
+            line.total_lst_price = (
+                line.product_id.lst_price
+                * line.quantity
+                * (1 - line.sale_discount / 100.0)
+            )
+            line.total_standard_price = line.product_id.standard_price * line.quantity
 
     def get_sale_order_line_vals(self, line, order):
         self.ensure_one()

--- a/sale_product_pack/tests/test_sale_product_pack.py
+++ b/sale_product_pack/tests/test_sale_product_pack.py
@@ -221,3 +221,9 @@ class TestSaleProductPack(SavepointCase):
         self.assertEqual(sequence_tp, self.sale_order.order_line[5].sequence)
         self.assertEqual(sequence_tp, self.sale_order.order_line[6].sequence)
         self.assertEqual(sequence_tp, self.sale_order.order_line[7].sequence)
+
+    def test_get_pack_line_total_price(self):
+        # Check pack line total prices if equal to product prices
+        pack_line = self.env.ref("product_pack.pack_cpu_detailed_totalized_1")
+        self.assertEqual(1700.0, pack_line.total_standard_price)
+        self.assertEqual(1755.0, pack_line.total_lst_price)

--- a/sale_product_pack/views/product_pack_line_views.xml
+++ b/sale_product_pack/views/product_pack_line_views.xml
@@ -12,6 +12,8 @@
                     name="sale_discount"
                     groups="product.group_discount_per_so_line"
                 />
+                <field name="total_standard_price" />
+                <field name="total_lst_price" />
             </field>
         </field>
     </record>
@@ -24,6 +26,16 @@
                 <field
                     name="sale_discount"
                     groups="product.group_discount_per_so_line"
+                />
+                <field
+                    name="total_standard_price"
+                    sum="Total Cost Price"
+                    optional="hide"
+                />
+                <field
+                    name="total_lst_price"
+                    sum="Total Public Price"
+                    optional="hide"
                 />
             </field>
         </field>


### PR DESCRIPTION
This can be helpfull to define sale price for the product pack
We added 2 computed fields total standard price and total public price in product pack lines to help the user to define the pack sale price