### PR TITLE
[16.0][FIX] stock_product_pack Use already calculated qtys

### DIFF
--- a/stock_product_pack/models/product_product.py
+++ b/stock_product_pack/models/product_product.py
@@ -28,15 +28,26 @@ class ProductProduct(models.Model):
                 subproduct_stock = subproduct.product_id
                 sub_qty = subproduct.quantity
                 if sub_qty:
-                    pack_qty_available.append(
-                        math.floor(subproduct_stock.qty_available / sub_qty)
-                    )
-                    pack_virtual_available.append(
-                        math.floor(subproduct_stock.virtual_available / sub_qty)
-                    )
-                    pack_free_qty.append(
-                        math.floor(subproduct_stock.free_qty / sub_qty)
-                    )
+                    if subproduct_stock.id in res:
+                        pack_qty_available.append(
+                            res[subproduct_stock.id]["qty_available"] / sub_qty
+                        )
+                        pack_virtual_available.append(
+                            res[subproduct_stock.id]["virtual_available"] / sub_qty
+                        )
+                        pack_free_qty.append(
+                            res[subproduct_stock.id]["free_qty"] / sub_qty
+                        )
+                    else:
+                        pack_qty_available.append(
+                            math.floor(subproduct_stock.qty_available / sub_qty)
+                        )
+                        pack_virtual_available.append(
+                            math.floor(subproduct_stock.virtual_available / sub_qty)
+                        )
+                        pack_free_qty.append(
+                            math.floor(subproduct_stock.free_qty / sub_qty)
+                        )
             res[product.id] = {
                 "qty_available": (pack_qty_available and min(pack_qty_available) or 0),
                 "free_qty": (pack_free_qty and min(pack_free_qty) or 0),

--- a/stock_product_pack/tests/test_stock_product_pack.py
+++ b/stock_product_pack/tests/test_stock_product_pack.py
@@ -175,6 +175,10 @@ class TestSaleProductPack(TransactionCase):
         wizard.process()
         self.assertEqual(self.pack_dc.virtual_available, 5)
         self.assertEqual(self.pack_dc.qty_available, 5)
+        all_product_ids = self.env["product.product"]
+        all_product_ids |= self.pack_dc
+        all_product_ids |= components
+        all_product_ids._compute_quantities()
 
     def test_pack_with_dont_move_the_parent(self):
         """Run a procurement for prod pack products when there are only 5 in stock then


### PR DESCRIPTION
There are some cases where it may occur that the pack quantities and the components are attempted to be calculated at the same time, resulting in a logical error. When trying to calculate the pack quantities based on their components and these components being calculated at that very moment, the components return quantities equal to 0 and the outcome is that the calculation of the pack quantities is not consistent.

This happens, for instance, in remote cases where on a delivery note all products (pack + components) are attempted to be added, or in more common cases related to other modules from the same repository that necessitate the creation of a module to solve it.

With this fix, we solve a consistency error that may occur in this module independently and in future and parallel modules.