### PR TITLE
[16.0][FIX] product_pack: pack_line_ids on product.product

### DIFF
--- a/product_pack/views/product_product_views.xml
+++ b/product_pack/views/product_product_views.xml
@@ -9,7 +9,7 @@
         <field name="arch" type="xml">
             <group name="group_pack">
                 <group string="Pack Products" colspan="4">
-                    <field name="pack_line_ids" nolabel="1" />
+                    <field name="pack_line_ids" nolabel="1" colspan="2" />
                 </group>
             </group>
         </field>


### PR DESCRIPTION
This commit fix the field display on product.product view.
![image](https://github.com/OCA/product-pack/assets/69461150/515f0d8e-f04b-4771-bd43-f3e5316d0428)