### PR TITLE
[16.0][FIX] sale_product_pack: keep order lines in order

### DIFF
--- a/sale_product_pack/models/sale_order_line.py
+++ b/sale_product_pack/models/sale_order_line.py
@@ -75,7 +75,6 @@ class SaleOrderLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        new_vals = []
         res = self.browse()
         for elem in vals_list:
             product = self.env["product.product"].browse(elem.get("product_id"))
@@ -84,8 +83,7 @@ class SaleOrderLine(models.Model):
                 line.expand_pack_line()
                 res |= line
             else:
-                new_vals.append(elem)
-        res |= super().create(new_vals)
+                res |= super().create([elem])
         return res
 
     def write(self, vals):


### PR DESCRIPTION
The issue:
When add diferent sale orders, packs and their components are added first, and then the other order lines

To reproduce the error:
New sale order
(1) Add a sale order line 
(2) Add a sale order line (pack)
Save the sale order

Behavior before this PR:
The sale order will show:
(2) The pack sale order line and components first
(1) The other sale order line

Behavior after this PR:
Hold the order of sale order lines 1 and 2

[Untitled_ Aug 4, 2023 3_14 PM.webm](https://github.com/OCA/product-pack/assets/90717087/df10d2f5-13cd-4692-93ce-2375a4fae42c)
