### PR TITLE
[14.0][FIX] sale_product_pack: Button action text should be a hint

### DIFF
--- a/sale_product_pack/views/product_pack_line_views.xml
+++ b/sale_product_pack/views/product_pack_line_views.xml
@@ -39,7 +39,7 @@
                 <field name="pack_modifiable" invisible="True" />
                 <field name="pack_parent_line_id" invisible="True" />
                 <button
-                    string="Parent Pack is not modifiable"
+                    title="Parent Pack is not modifiable"
                     name="action_open_parent_pack_product_view"
                     type="object"
                     attrs="{'invisible': ['|', ('pack_parent_line_id', '=', False), ('pack_modifiable', '=', True)]}"


### PR DESCRIPTION
Otherwise it takes up too much space on the sales view.

Before
![image](https://github.com/OCA/product-pack/assets/22446243/f3b5f3be-9e5a-446c-9d29-6221d71670f9)

After
![image](https://github.com/OCA/product-pack/assets/22446243/ff93db4a-4333-4172-818f-6df2b5b9c012)
