### PR TITLE
[16.0][FIX] product_pack: Ignore pack_component_price for non_detailed pack

### DIFF
--- a/product_pack/models/product_template.py
+++ b/product_pack/models/product_template.py
@@ -124,7 +124,11 @@ class ProductTemplate(models.Model):
             )
         is_pack |= self.pack_ok and (
             (self.pack_type == "detailed" and self.pack_component_price == "totalized")
-            or self.pack_type == "non_detailed"
+            or (
+                self.pack_type == "non_detailed"
+                and
+                self.pack_component_price != "ignored"
+            )
         )
         return is_pack
 

--- a/product_pack/views/product_template_views.xml
+++ b/product_pack/views/product_template_views.xml
@@ -29,7 +29,7 @@
                             />
                             <field
                                 name="pack_component_price"
-                                attrs="{'required':[('pack_type', '=', 'detailed')], 'invisible':[('pack_type', '!=', 'detailed')]}"
+                                attrs="{'required':[('pack_type', '=', 'detailed')]}"
                             />
                             <field
                                 name="pack_modifiable"


### PR DESCRIPTION
For a non-detailed pack, the user should be able to choose if the component prices should be totalized or ignored.