### PR TITLE
[16.0][FIX] product_pack: fix in price list search

### DIFF
--- a/product_pack/models/product_product.py
+++ b/product_pack/models/product_product.py
@@ -47,6 +47,7 @@ class ProductProduct(models.Model):
             # it will be converted again by pp._compute_price_rule, so if
             # that is the case we convert the amounts to the pack currency
             if pricelist_id_or_name:
+                pricelist = None
                 if isinstance(pricelist_id_or_name, list):
                     pricelist_id_or_name = pricelist_id_or_name[0]
                 if isinstance(pricelist_id_or_name, str):

--- a/product_pack/tests/test_product_pack.py
+++ b/product_pack/tests/test_product_pack.py
@@ -117,3 +117,20 @@ class TestProductPack(ProductPackCommon, TransactionCase):
         pack.pack_type = "detailed"
         pack.pack_component_price = "totalized"
         self.assertTrue(pack.pack_modifiable_invisible)
+
+    def test_price_compute_with_pricelist_context(self):
+        # Ensure that the price_compute method correctly handles the
+        # price list context when the price list is missing.
+        product_pack = self.env.ref("product_pack.product_pack_cpu_detailed_totalized")
+        component_1 = self.env.ref("product_pack.pack_cpu_detailed_totalized_1")
+        component_1.product_id.list_price = 30.0
+        component_2 = self.env.ref("product_pack.pack_cpu_detailed_totalized_3")
+        component_2.product_id.list_price = 15.0
+        component_3 = self.env.ref("product_pack.pack_cpu_detailed_components_4")
+        component_3.product_id.list_price = 5.0
+        price = (
+            product_pack.with_context(pricelist="pricelist test")
+            .price_compute("list_price")
+            .get(product_pack.id)
+        )
+        self.assertEqual(price, 50.0)


### PR DESCRIPTION
When searching for a price list through text, that is, without selecting a specific one in the search bar of the product.product model and not finding any, it triggers an initialization error for the variable pricelist when the "if pricelist..." condition is encountered.