### PR TITLE
[FIX]website_sale_product_pack: element not founded

### DIFF
--- a/website_sale_product_pack/__manifest__.py
+++ b/website_sale_product_pack/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Website Sale Product Pack",
     "category": "E-Commerce",
     "summary": "Compatibility module of product pack with e-commerce",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "license": "AGPL-3",
     "depends": ["website_sale", "sale_product_pack"],
     "data": ["views/templates.xml"],

--- a/website_sale_product_pack/views/templates.xml
+++ b/website_sale_product_pack/views/templates.xml
@@ -19,7 +19,7 @@
             <attribute name="t-if">not line.pack_parent_line_id</attribute>
         </xpath>
         <!-- We don't show the image of the components to have a clean summary -->
-        <xpath expr="//td[hasclass('td-img', 'text-center')]" position="attributes">
+        <xpath expr="//td[hasclass('td-img')]" position="attributes">
             <attribute
                 name="t-if"
             >line.product_id.product_tmpl_id and not line.pack_parent_line_id</attribute>


### PR DESCRIPTION
Fixing this error: 
ValueError: El elemento: xpath expr="//td[hasclass('td-img', 'text-center')]" position="attributes
no puede ser localizado en la vista padre