### PR TITLE
[17.0][FIX] sale_product_pack: Define the correct sequence of sale order lines

### DIFF
--- a/sale_product_pack/models/product_pack_line.py
+++ b/sale_product_pack/models/product_pack_line.py
@@ -16,7 +16,6 @@ class ProductPack(models.Model):
         quantity = self.quantity * line.product_uom_qty
         line_vals = {
             "order_id": order.id,
-            "sequence": line.sequence,
             "product_id": self.product_id.id or False,
             "pack_parent_line_id": line.id,
             "pack_depth": line.pack_depth + 1,


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/product-pack/pull/179

Define the correct sequence of sale order lines

Previously, the product pack line sequence was defined for the “extra” lines

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT50677