### PR TITLE
[16.0][FIX] stock_product_pack: Display Delivery Slip data correctly sorted in pack products

### DIFF
--- a/stock_product_pack/README.rst
+++ b/stock_product_pack/README.rst
@@ -80,6 +80,7 @@ Contributors
   * Pedro M. Baeza
   * Sergio Teruel
   * João Marques
+  * Víctor Martínez
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_product_pack/models/__init__.py
+++ b/stock_product_pack/models/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import product_template
 from . import product_product
+from . import stock_move_line
 from . import stock_rule

--- a/stock_product_pack/models/stock_move_line.py
+++ b/stock_product_pack/models/stock_move_line.py
@@ -1,0 +1,32 @@
+# Copyright 2024 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    # TODO: Check if it is possible to remove it
+    def _get_aggregated_product_quantities(self, **kwargs):
+        """If any product pack has been used and is consumable we must reorder.
+        Example of picking:
+        - Consumable product (pack): sequence 10 (stock.move, id=1)
+        - Storable product A: sequence 11 (stock.move, id=2)
+        - Storable product B: sequence 12 (stock.move, id=3)
+        Confirm picking (Storable products have stock) and we get the following:
+        - stock.move.line, id=1, move_id=2 (Storable product A)
+        - stock.move.line, id=2, move_id=3 (Storable product B)
+        - stock.move.line, id=3, move_id=1 (Consumable product (pack))
+        Done picking and print Delivery Slip report, this method is used to print table,
+        and we get a confusing order, so we must reorder them according to the sequence
+        of the linked stock.move.
+        This is a known side effect in the stock addon when using consumable product +
+        storable products but for now we only reorder for product packs.
+        """
+        if any(
+            sml.product_id.pack_ok and sml.product_id.detailed_type == "consu"
+            for sml in self
+        ):
+            self = self.sorted(key=lambda x: x.move_id.sequence)
+        return super()._get_aggregated_product_quantities(**kwargs)

--- a/stock_product_pack/readme/CONTRIBUTORS.rst
+++ b/stock_product_pack/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
   * Pedro M. Baeza
   * Sergio Teruel
   * João Marques
+  * Víctor Martínez

--- a/stock_product_pack/static/description/index.html
+++ b/stock_product_pack/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -426,6 +425,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pedro M. Baeza</li>
 <li>Sergio Teruel</li>
 <li>João Marques</li>
+<li>Víctor Martínez</li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
Display Delivery Slip data correctly sorted in pack products

If any product pack has been used and is consumable we must reorder.
Example of picking:
- Consumable product (pack): sequence 10 (stock.move, id=1)
- Storable product A: sequence 11 (stock.move, id=2)
- Storable product B: sequence 12 (stock.move, id=3)

Confirm picking (Storable products have stock) and we get the following:
- stock.move.line, id=1, move_id=2 (Storable product A)
- stock.move.line, id=2, move_id=3 (Storable product B)
- stock.move.line, id=3, move_id=1 (Consumable product (pack))

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT50677