### PR TITLE
Revert "[FIX] sale_product_pack: Define the correct sequence of sale order lines"

### DIFF
--- a/sale_product_pack/models/product_pack_line.py
+++ b/sale_product_pack/models/product_pack_line.py
@@ -16,6 +16,7 @@ class ProductPack(models.Model):
         quantity = self.quantity * line.product_uom_qty
         line_vals = {
             "order_id": order.id,
+            "sequence": line.sequence,
             "product_id": self.product_id.id or False,
             "pack_parent_line_id": line.id,
             "pack_depth": line.pack_depth + 1,

--- a/sale_product_pack/models/sale_order_line.py
+++ b/sale_product_pack/models/sale_order_line.py
@@ -52,11 +52,8 @@ class SaleOrderLine(models.Model):
         # only want to update prices
         vals_list = []
         if self.product_id.pack_ok and self.pack_type == "detailed":
-            new_sequence = self.sequence + 1
             for subline in self.product_id.get_pack_lines():
                 vals = subline.get_sale_order_line_vals(self, self.order_id)
-                vals["sequence"] = new_sequence
-                new_sequence += 1
                 if write:
                     existing_subline = first(
                         self.pack_child_line_ids.filtered(

--- a/sale_product_pack/tests/test_sale_product_pack.py
+++ b/sale_product_pack/tests/test_sale_product_pack.py
@@ -71,8 +71,13 @@ class TestSaleProductPack(TransactionCase):
         )
         # After create, there will be four lines
         self.assertEqual(len(self.sale_order.order_line), 4)
+        pack_line = self.sale_order.order_line.filtered(
+            lambda pline: pline.product_id == product_cp
+        )
+        # Check if sequence is the same as pack product one
+        sequence = pack_line.sequence
         self.assertEqual(
-            [10, 11, 12, 13],
+            [sequence, sequence, sequence, sequence],
             self.sale_order.order_line.mapped("sequence"),
         )
         # The products of those four lines are the main product pack and its
@@ -245,21 +250,26 @@ class TestSaleProductPack(TransactionCase):
                 "name": product_cp.name,
                 "product_id": product_cp.id,
                 "product_uom_qty": 1,
-                "sequence": 10,
             },
             {
                 "order_id": self.sale_order.id,
                 "name": product_tp.name,
                 "product_id": product_tp.id,
                 "product_uom_qty": 1,
-                "sequence": 20,
             },
         ]
         self.env["sale.order.line"].create(vals)
         # After create, there will be eight lines (4 + 4)
         self.assertEqual(len(self.sale_order.order_line), 8)
         # Check if lines are well ordered
-        self.assertEqual(
-            [10, 11, 12, 13, 20, 21, 22, 23],
-            self.sale_order.order_line.mapped("sequence"),
-        )
+        self.assertEqual(self.sale_order.order_line[0].product_id, product_cp)
+        sequence_cp = self.sale_order.order_line[0].sequence
+        self.assertEqual(sequence_cp, self.sale_order.order_line[1].sequence)
+        self.assertEqual(sequence_cp, self.sale_order.order_line[2].sequence)
+        self.assertEqual(sequence_cp, self.sale_order.order_line[3].sequence)
+
+        self.assertEqual(self.sale_order.order_line[4].product_id, product_tp)
+        sequence_tp = self.sale_order.order_line[4].sequence
+        self.assertEqual(sequence_tp, self.sale_order.order_line[5].sequence)
+        self.assertEqual(sequence_tp, self.sale_order.order_line[6].sequence)
+        self.assertEqual(sequence_tp, self.sale_order.order_line[7].sequence)


### PR DESCRIPTION
Reverts https://github.com/OCA/product-pack/pull/179

See https://github.com/OCA/product-pack/pull/180#pullrequestreview-2282118432