### PR TITLE
[17.0][FIX] sale_product_pack: Respect the order of the lines to be added

### DIFF
--- a/sale_product_pack/README.rst
+++ b/sale_product_pack/README.rst
@@ -122,13 +122,13 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-.. |maintainer-ernestotejeda| image:: https://github.com/ernestotejeda.png?size=40px
-    :target: https://github.com/ernestotejeda
-    :alt: ernestotejeda
+.. |maintainer-victoralmau| image:: https://github.com/victoralmau.png?size=40px
+    :target: https://github.com/victoralmau
+    :alt: victoralmau
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-ernestotejeda| 
+|maintainer-victoralmau| 
 
 This module is part of the `OCA/product-pack <https://github.com/OCA/product-pack/tree/17.0/sale_product_pack>`_ project on GitHub.
 

--- a/sale_product_pack/__manifest__.py
+++ b/sale_product_pack/__manifest__.py
@@ -7,7 +7,7 @@
     "summary": "This module allows you to sell product packs",
     "website": "https://github.com/OCA/product-pack",
     "author": "NaN·tic, ADHOC SA, Tecnativa, Odoo Community Association (OCA)",
-    "maintainers": ["ernestotejeda"],
+    "maintainers": ["victoralmau"],
     "license": "AGPL-3",
     "depends": ["product_pack", "sale"],
     "data": ["security/ir.model.access.csv", "views/product_pack_line_views.xml"],

--- a/sale_product_pack/models/sale_order_line.py
+++ b/sale_product_pack/models/sale_order_line.py
@@ -76,18 +76,22 @@ class SaleOrderLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        new_vals = []
-        res = self.browse()
-        for elem in vals_list:
-            product = self.env["product.product"].browse(elem.get("product_id"))
-            if product and product.pack_ok and product.pack_type != "non_detailed":
+        """Only when strictly necessary (a product is a pack) will be created line
+        by line, this is necessary to maintain the correct order.
+        """
+        product_ids = [elem.get("product_id") for elem in vals_list]
+        products = self.env["product.product"].browse(product_ids)
+        if any(p.pack_ok and p.pack_type != "non_detailed" for p in products):
+            res = self.browse()
+            for elem in vals_list:
                 line = super().create([elem])
-                line.expand_pack_line()
-                res |= line
-            else:
-                new_vals.append(elem)
-        res |= super().create(new_vals)
-        return res
+                product = line.product_id
+                res += line
+                if product and product.pack_ok and product.pack_type != "non_detailed":
+                    line.expand_pack_line()
+            return res
+        else:
+            return super().create(vals_list)
 
     def write(self, vals):
         res = super().write(vals)

--- a/sale_product_pack/static/description/index.html
+++ b/sale_product_pack/static/description/index.html
@@ -467,7 +467,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/ernestotejeda"><img alt="ernestotejeda" src="https://github.com/ernestotejeda.png?size=40px" /></a></p>
+<p><a class="reference external image-reference" href="https://github.com/victoralmau"><img alt="victoralmau" src="https://github.com/victoralmau.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/product-pack/tree/17.0/sale_product_pack">OCA/product-pack</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/sale_product_pack/tests/test_sale_product_pack.py
+++ b/sale_product_pack/tests/test_sale_product_pack.py
@@ -1,10 +1,10 @@
 # Copyright 2019 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestSaleProductPack(TransactionCase):
+class TestSaleProductPack(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -238,7 +238,7 @@ class TestSaleProductPack(TransactionCase):
         pack_line_update = pack_line.with_context(update_pricelist=True)
         self.assertTrue(pack_line_update.do_no_expand_pack_lines)
 
-    def test_create_several_lines(self):
+    def test_create_several_lines_01(self):
         # Create two sale order lines with two pack products
         # Check 8 lines are created
         # Check lines sequences and order are respected
@@ -273,3 +273,65 @@ class TestSaleProductPack(TransactionCase):
         self.assertEqual(sequence_tp, self.sale_order.order_line[5].sequence)
         self.assertEqual(sequence_tp, self.sale_order.order_line[6].sequence)
         self.assertEqual(sequence_tp, self.sale_order.order_line[7].sequence)
+
+    def test_create_several_lines_02(self):
+        # Create two sale order lines with pack product
+        # Check 5 lines are created
+        # Check lines sequences and order are respected
+        product_cp = self.env.ref("product_pack.product_pack_cpu_detailed_components")
+        product = self.env["product.product"].create({"name": "Test product"})
+        vals = [
+            {
+                "order_id": self.sale_order.id,
+                "name": product.name,
+                "product_id": product.id,
+                "product_uom_qty": 1,
+            },
+            {
+                "order_id": self.sale_order.id,
+                "name": product_cp.name,
+                "product_id": product_cp.id,
+                "product_uom_qty": 1,
+            },
+        ]
+        self.env["sale.order.line"].create(vals)
+        # After create, there will be eight lines (1 + 4)
+        self.assertEqual(len(self.sale_order.order_line), 5)
+        # Check if lines are well ordered
+        self.assertEqual(self.sale_order.order_line[0].product_id, product)
+        self.assertEqual(self.sale_order.order_line[1].product_id, product_cp)
+        sequence_tp = self.sale_order.order_line[1].sequence
+        self.assertEqual(sequence_tp, self.sale_order.order_line[2].sequence)
+        self.assertEqual(sequence_tp, self.sale_order.order_line[3].sequence)
+        self.assertEqual(sequence_tp, self.sale_order.order_line[4].sequence)
+
+    def test_create_several_lines_03(self):
+        # Create two sale order lines with pack product
+        # Check 5 lines are created
+        # Check lines sequences and order are respected
+        product_cp = self.env.ref("product_pack.product_pack_cpu_detailed_components")
+        product = self.env["product.product"].create({"name": "Test product"})
+        vals = [
+            {
+                "order_id": self.sale_order.id,
+                "name": product_cp.name,
+                "product_id": product_cp.id,
+                "product_uom_qty": 1,
+            },
+            {
+                "order_id": self.sale_order.id,
+                "name": product.name,
+                "product_id": product.id,
+                "product_uom_qty": 1,
+            },
+        ]
+        self.env["sale.order.line"].create(vals)
+        # After create, there will be eight lines (4 + 1)
+        self.assertEqual(len(self.sale_order.order_line), 5)
+        # Check if lines are well ordered
+        self.assertEqual(self.sale_order.order_line[0].product_id, product_cp)
+        sequence_tp = self.sale_order.order_line[0].sequence
+        self.assertEqual(sequence_tp, self.sale_order.order_line[1].sequence)
+        self.assertEqual(sequence_tp, self.sale_order.order_line[2].sequence)
+        self.assertEqual(sequence_tp, self.sale_order.order_line[3].sequence)
+        self.assertEqual(self.sale_order.order_line[4].product_id, product)


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/product-pack/pull/186

Respect the order of the lines to be added

**Before**
![antes](https://github.com/user-attachments/assets/491037b5-5fd9-4e9a-ac62-d93136ef0099)

**After**
![despues](https://github.com/user-attachments/assets/9785ae9b-7116-4584-8105-ae6336b4d43c)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT51380