### PR TITLE
[17.0][FIX] website_sale_product_pack: add decorator to remove warnings

### DIFF
--- a/website_sale_product_pack/controllers/main.py
+++ b/website_sale_product_pack/controllers/main.py
@@ -1,9 +1,10 @@
-from odoo.http import request
+from odoo.http import request, route
 
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class WebsiteSale(WebsiteSale):
+    @route()
     def shop(
         self,
         page=0,

--- a/website_sale_product_pack/controllers/variant.py
+++ b/website_sale_product_pack/controllers/variant.py
@@ -1,9 +1,10 @@
-from odoo.http import request
+from odoo.http import request, route
 
 from odoo.addons.website_sale.controllers.variant import WebsiteSaleVariantController
 
 
 class WebsiteSaleVariantController(WebsiteSaleVariantController):
+    @route()
     def get_combination_info_website(
         self,
         product_template_id,


### PR DESCRIPTION
Added `route` decorator to fix annoying warnings:

```
2024-11-22 07:57:10,327 18 WARNING b5a7dddd5-1e5e-4584-9d8f-426cb5efd411 odoo.http: The endpoint odoo.addons.website_sale_product_pack.controllers.main.WebsiteSale.shop is not decorated by @route(), decorating it myself. 
2024-11-22 07:57:10,351 18 WARNING b5a7dddd5-1e5e-4584-9d8f-426cb5efd411 odoo.http: The endpoint odoo.addons.website_sale_product_pack.controllers.variant.WebsiteSaleVariantController.get_combination_info_website is not decorated by @route(), decorating it myself.
```