### PR TITLE
[FIX] sale_product_pack: _get_update_prices_lines refactor

### DIFF
--- a/sale_product_pack/models/sale_order.py
+++ b/sale_product_pack/models/sale_order.py
@@ -60,12 +60,7 @@ class SaleOrder(models.Model):
 
     def _get_update_prices_lines(self):
         res = super()._get_update_prices_lines()
-        result = self.order_line.browse()
-        index = 0
-        while index < len(res):
-            line = res[index]
-            result |= line
-            index += 1
-            if line.product_id.pack_ok and line.pack_type == "detailed":
-                index += len(line.product_id.pack_line_ids)
-        return result
+        return res.filtered(
+            lambda line: not line.pack_parent_line_id
+            or line.pack_parent_line_id.pack_component_price == "detailed"
+        )

--- a/sale_product_pack/models/sale_order.py
+++ b/sale_product_pack/models/sale_order.py
@@ -60,7 +60,4 @@ class SaleOrder(models.Model):
 
     def _get_update_prices_lines(self):
         res = super()._get_update_prices_lines()
-        return res.filtered(
-            lambda line: not line.pack_parent_line_id
-            or line.pack_parent_line_id.pack_component_price == "detailed"
-        )
+        return res.filtered(lambda line: not line.pack_parent_line_id)


### PR DESCRIPTION
This PR was created because we found and issue when changing the pricelist on packs that have been modified. When an user modifies some of the components of the pack, the index calculated on the _get_update_prices_lines remains with a previous value and the price is not updated correctly (the last line on the pack is not updated).
We based our refactor on this [PR](https://github.com/OCA/product-pack/pull/173/commits/01cf6118f159919179da1b3889a58d0159319c79) made a few weeks ago on version 17 which resolves another issues apart from this one and it is already reviewed and merged.

Steps to reproduce the error:
- Add a pack "detailled" to a sale order
- Add one extra product (which is not a pack)
- Edit the pack adding a new component to pack line
- On the previous sale order, change the pricelist (be sure that on the new pricelist all items should change the price. Set for example a discount to all products)
Result: the pack should change the price of every component, but the last order line will not be updated due to a difference in the index inside the while loop (it would not take into account the last item).

