### PR TITLE
[17][FIX]product_pack: args in _get_product_price/s methods

### DIFF
--- a/product_pack/models/product_pricelist.py
+++ b/product_pack/models/product_pricelist.py
@@ -4,7 +4,7 @@ from odoo import models
 class Pricelist(models.Model):
     _inherit = "product.pricelist"
 
-    def _get_product_price(self, product, quantity, uom=None, date=False, **kwargs):
+    def _get_product_price(self, product, *args, **kwargs):
         """Compute the pricelist price for the specified pack product, qty & uom.
 
         :returns: unit price of the pack product + components,
@@ -20,32 +20,24 @@ class Pricelist(models.Model):
             ):
                 pack_price = 0
             else:
-                pack_price = self._compute_price_rule(
-                    product, quantity, uom=uom, date=date, **kwargs
-                )[product.id][0]
+                pack_price = self._compute_price_rule(product, *args, **kwargs)[
+                    product.id
+                ][0]
 
             for line in product.sudo().pack_line_ids:
-                pack_price += line._get_pack_line_price(
-                    self, quantity, uom=uom, date=date, **kwargs
-                )
+                pack_price += line._get_pack_line_price(self, *args, **kwargs)
             return pack_price
         else:
-            return super()._get_product_price(
-                product=product, quantity=quantity, uom=uom, date=date, **kwargs
-            )
+            return super()._get_product_price(product, *args, **kwargs)
 
-    def _get_products_price(self, products, quantity, uom=None, date=False, **kwargs):
+    def _get_products_price(self, products, *args, **kwargs):
         """Compute the pricelist price for the specified pack product, qty & uom.
 
         :returns: unit price of the pack product + components,
                   considering pricelist rules
         """
         packs, no_packs = products.split_pack_products()
-        res = super()._get_products_price(
-            no_packs, quantity=quantity, uom=uom, date=date, **kwargs
-        )
+        res = super()._get_products_price(no_packs, *args, **kwargs)
         for pack in packs:
-            res[pack.id] = self._get_product_price(
-                product=pack, quantity=quantity, uom=uom, date=date, **kwargs
-            )
+            res[pack.id] = self._get_product_price(pack, *args, **kwargs)
         return res


### PR DESCRIPTION
The arguments of the methods '_get_product_price' and '_get_product_prices' changed on product_pricelist on native odoo from (self, product, quantity, uom=None, date=False, **kwargs) to (self, product, *args, **kwargs). 

Commit of the change in  Odoo: https://github.com/odoo/odoo/commit/83c52575d0ce3d7deb1737c622c6ce366db8c31b#diff-21fdb0b99c09254c9445e27ceee2d2e27503e93d9dd99481c010d92226db6f75