### PR TITLE
[FIX] sale_product_pack: adjust discount formula for detailed packs

### DIFF
--- a/sale_product_pack/models/sale_order_line.py
+++ b/sale_product_pack/models/sale_order_line.py
@@ -153,7 +153,11 @@ class SaleOrderLine(models.Model):
         if self.pack_parent_line_id.pack_component_price == "detailed":
             for pack_line in self.pack_parent_line_id.product_id.pack_line_ids:
                 if pack_line.product_id == self.product_id:
-                    discount = pack_line.sale_discount
+                    discount = 100.0 - (
+                        (100.0 - self.discount)
+                        * (100.0 - pack_line.sale_discount)
+                        / 100.0
+                    )
                     break
         return discount
 


### PR DESCRIPTION
The discount formula for detailed packs has been updated to address inconsistencies when pricelists explicitly display discounts.

The new formula ensures accurate representation of the combined discount by correctly factoring in both the parent pack and component discounts.

Example:

Parent pack discount: 5%
Component A discount: 10%
Component B discount: 20%
The issue occurred when pricelists explicitly displayed discounts. For example, when the pricelist showed the discount percentage but did not properly calculate the combined effect of the pack discount and the component discounts, the displayed total was inconsistent.

With the new formula:

Component A effective discount:
100.0 - ((100.0 - 5.0) * (100.0 - 10.0) / 100.0) = 14.5%
Component B effective discount:
100.0 - ((100.0 - 5.0) * (100.0 - 20.0) / 100.0) = 24.0% 
