### PR TITLE
[18.0][IMP] product_pack: Don't depend on demo data for tests + simplification

### DIFF
--- a/product_pack/__manifest__.py
+++ b/product_pack/__manifest__.py
@@ -7,7 +7,7 @@
     "summary": "This module allows you to set a product as a Pack",
     "website": "https://github.com/OCA/product-pack",
     "author": "NaN·tic, ADHOC SA, Tecnativa, Odoo Community Association (OCA)",
-    "maintainers": ["ernestotejeda"],
+    "maintainers": ["pedrobaeza"],
     "license": "AGPL-3",
     "depends": ["product"],
     "data": [

--- a/product_pack/tests/common.py
+++ b/product_pack/tests/common.py
@@ -1,27 +1,46 @@
 # Copyright 2021 ACSONE SA/NV
+# Copyright 2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import Command
+from odoo.tests import TransactionCase
 
 
-class ProductPackCommon:
+class ProductPackCommon(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.company = cls.env.company
         cls.product_pack_line_obj = cls.env["product.pack.line"]
-        cls.cpu_detailed = cls.env.ref(
-            "product_pack.product_pack_cpu_detailed_components"
+        cls.component1 = cls.env["product.product"].create(
+            {"name": "Pack component 1", "list_price": 20, "company_id": cls.company.id}
         )
-        vals = {
-            "name": "Company Pack 2",
-        }
-        cls.company_2 = cls.env["res.company"].create(vals)
+        cls.component2 = cls.env["product.product"].create(
+            {"name": "Pack component 2", "list_price": 30, "company_id": cls.company.id}
+        )
+        cls.pack = cls.env["product.product"].create(
+            {
+                "name": "Test product pack",
+                "company_id": cls.company.id,
+                "type": "service",
+                "list_price": 10,
+                "pack_ok": True,
+                "pack_type": "detailed",
+                "pack_component_price": "detailed",
+                "pack_line_ids": [
+                    Command.create({"product_id": cls.component1.id, "quantity": 2}),
+                    Command.create({"product_id": cls.component2.id, "quantity": 1}),
+                ],
+            }
+        )
+        cls.pack_line1 = cls.pack.pack_line_ids[0]
+        cls.pack_line2 = cls.pack.pack_line_ids[1]
+        cls.company_2 = cls.env["res.company"].create({"name": "Company Pack 2"})
         cls.discount_pricelist = cls.env["product.pricelist"].create(
             {
                 "name": "Discount",
                 "company_id": cls.env.company.id,
                 "item_ids": [
-                    (
-                        0,
-                        0,
+                    Command.create(
                         {
                             "applied_on": "3_global",
                             "compute_price": "percentage",

--- a/product_pack/tests/test_product_pack.py
+++ b/product_pack/tests/test_product_pack.py
@@ -2,104 +2,58 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from psycopg2 import IntegrityError
 
-from odoo.exceptions import ValidationError
+from odoo import Command, exceptions
 from odoo.tests import Form
-from odoo.tests.common import TransactionCase
 from odoo.tools import mute_logger
 
 from .common import ProductPackCommon
 
 
-class TestProductPack(ProductPackCommon, TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
+class TestProductPack(ProductPackCommon):
     def test_product_pack_recursion(self):
-        # Add pack product in its pack lines
-        # Check constraint raises
-        with self.assertRaises(ValidationError):
-            self.cpu_detailed.write(
-                {
-                    "pack_line_ids": [
-                        (
-                            0,
-                            0,
-                            {
-                                "product_id": self.cpu_detailed.id,
-                                "quantity": 1.0,
-                            },
-                        )
-                    ]
-                }
-            )
+        """Add pack product in its pack lines and check the constraint raises."""
+        with self.assertRaises(exceptions.ValidationError):
+            self.pack.pack_line_ids = [
+                Command.create({"product_id": self.pack.id, "quantity": 1.0})
+            ]
 
     @mute_logger("odoo.sql_db")
     def test_product_in_pack_unique(self):
-        # Add product that is already in the concerned pack
-        # Check constraint raises
-        product_line = self.env.ref("product.product_product_16")
+        """Add product that is already in the pack and check the constraint raises."""
         with self.assertRaises(IntegrityError), self.env.cr.savepoint():
-            self.cpu_detailed.write(
-                {
-                    "pack_line_ids": [
-                        (
-                            0,
-                            0,
-                            {
-                                "product_id": product_line.id,
-                                "quantity": 1.0,
-                            },
-                        )
-                    ]
-                }
-            )
+            self.pack.pack_line_ids = [
+                Command.create({"product_id": self.component1.id, "quantity": 1.0})
+            ]
 
     def test_get_pack_line_price(self):
         # Check pack line price from product one
-        component = self.env.ref("product_pack.pack_cpu_detailed_components_1")
-        component.product_id.list_price = 30.0
+        self.component2.list_price = 30
         self.assertEqual(
-            30.0,
-            self.cpu_detailed.pack_line_ids.filtered(
-                lambda cmp: cmp.product_id == component.product_id
-            )._pack_line_price_compute("list_price")[component.product_id.id],
+            self.pack_line2._pack_line_price_compute("list_price")[self.component2.id],
+            30,
         )
 
     def test_get_pack_lst_price(self):
-        # Check pack lst_price if totalized from components
-        pack = self.env.ref("product_pack.product_pack_cpu_detailed_totalized")
-        component_1 = self.env.ref("product_pack.pack_cpu_detailed_totalized_1")
-        component_1.product_id.list_price = 30.0
-        component_2 = self.env.ref("product_pack.pack_cpu_detailed_totalized_3")
-        component_2.product_id.list_price = 15.0
-        component_3 = self.env.ref("product_pack.pack_cpu_detailed_components_4")
-        component_3.product_id.list_price = 5.0
-        self.assertEqual(50.0, pack.lst_price)
+        """Check pack lst_price if totalized from components."""
+        self.pack.pack_component_price = "totalized"
+        self.assertEqual(self.pack.lst_price, 70)
 
     def test_pack_company(self):
-        # Try to assign pack lines with product that do not belong to pack
-        # company
-        component = self.env.ref("product_pack.pack_cpu_detailed_totalized_1")
-        with self.assertRaises(ValidationError), self.env.cr.savepoint():
-            component.product_id.company_id = self.company_2
+        """Try to assign pack lines with product that do not belong to pack company."""
+        with self.assertRaises(exceptions.ValidationError), self.env.cr.savepoint():
+            self.component1.company_id = self.company_2
 
     def test_pack_line_company(self):
-        # Try to assign pack lines with product that do not belong to pack
-        # company
-        pack = self.env.ref("product_pack.product_pack_cpu_detailed_totalized")
-        with self.assertRaises(ValidationError), self.env.cr.savepoint():
-            pack.company_id = self.company_2
+        """Try to assign pack lines with product that do not belong to pack company."""
+        with self.assertRaises(exceptions.ValidationError), self.env.cr.savepoint():
+            self.pack.company_id = self.company_2
 
     def test_pack_type(self):
-        # Change pack type from detailed to non detailed
-        pack = self.env.ref(
-            "product_pack.product_pack_cpu_detailed_components"
-        ).product_tmpl_id
-        pack.pack_modifiable = True
-        with Form(pack) as pack_form:
+        """Change pack type from detailed to non detailed."""
+        self.pack.pack_modifiable = True
+        with Form(self.pack.product_tmpl_id) as pack_form:
             pack_form.pack_type = "non_detailed"
-        self.assertFalse(pack_form.pack_modifiable)
+            self.assertFalse(pack_form.pack_modifiable)
 
     def test_pack_modifiable(self):
         # Pack is detailed with component price as detailed
@@ -108,43 +62,36 @@ class TestProductPack(ProductPackCommon, TransactionCase):
         # Pack modifiable invisible should be True
         # Set the Pack as detailed with component price as totalized
         # Pack modifiable invisible should be True
-        pack = self.env.ref(
-            "product_pack.product_pack_cpu_detailed_components"
-        ).product_tmpl_id
-        self.assertFalse(pack.pack_modifiable_invisible)
-        pack.pack_type = "non_detailed"
-        self.assertTrue(pack.pack_modifiable_invisible)
-        pack.pack_type = "detailed"
-        pack.pack_component_price = "totalized"
-        self.assertTrue(pack.pack_modifiable_invisible)
+        self.assertFalse(self.pack.pack_modifiable_invisible)
+        self.pack.pack_type = "non_detailed"
+        self.assertTrue(self.pack.pack_modifiable_invisible)
+        self.pack.pack_type = "detailed"
+        self.pack.pack_component_price = "totalized"
+        self.assertTrue(self.pack.pack_modifiable_invisible)
 
-    def test_pack_price_with_pricelist_context(self):
-        # Apply pricelist by context only for product packs (no components)
-
-        # Pack Detailed
-        pack = self.env.ref("product_pack.product_pack_cpu_detailed_components")
-        price = pack.with_context(
+    def test_pack_price_with_pricelist_context_detailed(self):
+        price = self.pack.with_context(
             whole_pack_price=True, pricelist=self.discount_pricelist.id
         )._get_contextual_price()
-        self.assertEqual(price, 2601.675)
+        self.assertEqual(price, 72)  # 80 (10 + 70) with 10% discount
 
-        # Pack Totalized
-        pack = self.env.ref("product_pack.product_pack_cpu_detailed_totalized")
-        price = pack.with_context(
+    def test_pack_price_with_pricelist_context_totalized(self):
+        self.pack.pack_component_price = "totalized"
+        price = self.pack.with_context(
+            whole_pack_price=True, pricelist=self.discount_pricelist.id
+        )._get_contextual_price()
+        self.assertEqual(price, 63)  # 70 with 10% discount
+
+    def test_pack_price_with_pricelist_context_ignored(self):
+        self.pack.pack_component_price = "ignored"
+        price = self.pack.with_context(
+            whole_pack_price=True, pricelist=self.discount_pricelist.id
+        )._get_contextual_price()
+        self.assertEqual(price, 9)  # 10 with 10% discount
+
+    def test_pack_price_with_pricelist_context_non_detailed(self):
+        self.pack.pack_type = "non_detailed"
+        price = self.pack.with_context(
             pricelist=self.discount_pricelist.id
         )._get_contextual_price()
-        self.assertEqual(price, 2574.0)
-
-        # Pack Ignored
-        pack = self.env.ref("product_pack.product_pack_cpu_detailed_ignored")
-        price = pack.with_context(
-            pricelist=self.discount_pricelist.id
-        )._get_contextual_price()
-        self.assertEqual(price, 27.675)
-
-        # Pack Non detailed
-        pack = self.env.ref("product_pack.product_pack_cpu_non_detailed")
-        price = pack.with_context(
-            pricelist=self.discount_pricelist.id
-        )._get_contextual_price()
-        self.assertEqual(price, 2574.0)
+        self.assertEqual(price, 63)  # 70 with 10% discount


### PR DESCRIPTION
Demo data can make tests to fail in integration environments or locally modified ones, so let's remove them and use data created on the test itself.

We also improve the containerization of the elements of the tests.

In the same movement, we have simplified the code of the test for doing the same with less lines and in a clearer way and change the old maintainer.

@Tecnativa 