### PR TITLE
[18.0][IMP] purchase_product_pack: Don't depend on demo data for tests + simplification

### DIFF
--- a/purchase_product_pack/tests/common.py
+++ b/purchase_product_pack/tests/common.py
@@ -1,0 +1,29 @@
+# Copyright 2025 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.addons.product_pack.tests.common import ProductPackCommon
+
+
+class TestPurchaseProductPackBase(ProductPackCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Test purchase pack"})
+        cls.pack.standard_price = 5
+        cls.component1.standard_price = 12
+        cls.component2.standard_price = 18
+        cls.purchase_order = cls.env["purchase.order"].create(
+            {"partner_id": cls.partner.id}
+        )
+
+    def _add_po_line(self, product=None, sequence=10):
+        product = product or self.pack
+        return self.env["purchase.order.line"].create(
+            {
+                "order_id": self.purchase_order.id,
+                "name": product.name,
+                "product_id": product.id,
+                "product_qty": 1,
+                "sequence": sequence,
+            }
+        )

--- a/purchase_product_pack/tests/test_purchase_product_pack.py
+++ b/purchase_product_pack/tests/test_purchase_product_pack.py
@@ -1,292 +1,124 @@
 # Copyright 2023 Camptocamp SA
+# Copyright 2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-from odoo.tests.common import TransactionCase
+from odoo import Command
 
-from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+from .common import TestPurchaseProductPackBase
 
 
-class TestPurchaseProductPack(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
-        cls.purchase_order = cls.env["purchase.order"].create(
-            {
-                "partner_id": cls.env.ref("base.res_partner_12").id,
-            }
-        )
-
-    def _get_component_costs_sum(self, product_pack):
-        component_prices = 0.0
-        for pack_line in product_pack.get_pack_lines():
-            product_line_price = pack_line.product_id.standard_price
-            component_prices += product_line_price * pack_line.quantity
-        return component_prices
-
+class TestPurchaseProductPack(TestPurchaseProductPackBase):
     def test_create_components_cost_order_line(self):
-        product_cp = self.env.ref("product_pack.product_pack_cpu_detailed_components")
-        line = self.env["purchase.order.line"].create(
-            {
-                "order_id": self.purchase_order.id,
-                "name": product_cp.name,
-                "product_id": product_cp.id,
-                "product_qty": 1,
-            }
-        )
-        # After create, there will be four lines
-        self.assertEqual(len(self.purchase_order.order_line), 4)
-        pack_line = self.purchase_order.order_line.filtered(
-            lambda pline: pline.product_id == product_cp
-        )
+        self._add_po_line()
+        # After create, there will be three lines
+        self.assertEqual(len(self.purchase_order.order_line), 3)
         # Check if sequence is the same as pack product one
-        sequence = pack_line.sequence
-        self.assertEqual(
-            [sequence, sequence, sequence, sequence],
-            self.purchase_order.order_line.mapped("sequence"),
-        )
-        # The products of those four lines are the main product pack and its
-        # product components
-        self.assertEqual(
-            self.purchase_order.order_line.mapped("product_id"),
-            product_cp | product_cp.get_pack_lines().mapped("product_id"),
-        )
+        for po_line in self.purchase_order.order_line:
+            self.assertEqual(po_line.sequence, 10)
+        # The products of those lines are the main product pack and its components
+        self.assertEqual(self.purchase_order.order_line[0].product_id, self.pack)
+        self.assertEqual(self.purchase_order.order_line[1].product_id, self.component1)
+        self.assertEqual(self.purchase_order.order_line[2].product_id, self.component2)
         # Check the subtotal on lines
-        self.assertAlmostEqual(line.price_subtotal, 20.5)
-        self.assertEqual(
-            (self.purchase_order.order_line - line).mapped("price_subtotal"),
-            [1700.0, 20.0, 876.0],
-        )
+        self.assertEqual(self.purchase_order.order_line[0].price_subtotal, 5)
+        self.assertEqual(self.purchase_order.order_line[1].price_subtotal, 24)
+        self.assertEqual(self.purchase_order.order_line[2].price_subtotal, 18)
 
     def test_create_ignored_cost_order_line(self):
-        product_tp = self.env.ref("product_pack.product_pack_cpu_detailed_ignored")
-        line = self.env["purchase.order.line"].create(
-            {
-                "order_id": self.purchase_order.id,
-                "name": product_tp.name,
-                "product_id": product_tp.id,
-                "product_qty": 1,
-            }
-        )
+        self.pack.pack_component_price = "ignored"
+        self._add_po_line()
         # After create, there will be four lines
-        self.assertEqual(len(self.purchase_order.order_line), 4)
+        self.assertEqual(len(self.purchase_order.order_line), 3)
         # The products of those four lines are the main product pack and its
         # product components
-        self.assertEqual(
-            self.purchase_order.order_line.mapped("product_id"),
-            product_tp | product_tp.get_pack_lines().mapped("product_id"),
-        )
+        self.assertEqual(self.purchase_order.order_line[0].product_id, self.pack)
+        self.assertEqual(self.purchase_order.order_line[1].product_id, self.component1)
+        self.assertEqual(self.purchase_order.order_line[2].product_id, self.component2)
         # All component lines have zero as subtotal
-        self.assertEqual(
-            (self.purchase_order.order_line - line).mapped("price_subtotal"), [0, 0, 0]
-        )
+        self.assertEqual(self.purchase_order.order_line[1].price_subtotal, 0)
+        self.assertEqual(self.purchase_order.order_line[2].price_subtotal, 0)
         # Pack price is different from the sum of component prices
-        self.assertAlmostEqual(line.price_subtotal, 20.5)
-        self.assertNotEqual(self._get_component_costs_sum(product_tp), 20.5)
+        self.assertEqual(self.purchase_order.order_line[0].price_subtotal, 5)
 
     def test_create_totalized_cost_order_line(self):
-        product_tp = self.env.ref("product_pack.product_pack_cpu_detailed_totalized")
-        line = self.env["purchase.order.line"].create(
-            {
-                "order_id": self.purchase_order.id,
-                "name": product_tp.name,
-                "product_id": product_tp.id,
-                "product_qty": 1,
-            }
-        )
+        self.pack.pack_component_price = "totalized"
+        self._add_po_line()
         # After create, there will be four lines
-        self.assertEqual(len(self.purchase_order.order_line), 4)
+        self.assertEqual(len(self.purchase_order.order_line), 3)
         # The products of those four lines are the main product pack and its
         # product components
-        self.assertEqual(
-            self.purchase_order.order_line.mapped("product_id"),
-            product_tp | product_tp.get_pack_lines().mapped("product_id"),
-        )
+        self.assertEqual(self.purchase_order.order_line[0].product_id, self.pack)
+        self.assertEqual(self.purchase_order.order_line[1].product_id, self.component1)
+        self.assertEqual(self.purchase_order.order_line[2].product_id, self.component2)
         # All component lines have zero as subtotal
-        self.assertAlmostEqual(
-            (self.purchase_order.order_line - line).mapped("price_subtotal"), [0, 0, 0]
-        )
+        self.assertEqual(self.purchase_order.order_line[1].price_subtotal, 0)
+        self.assertEqual(self.purchase_order.order_line[2].price_subtotal, 0)
         # Pack price is equal to the sum of component prices
-        self.assertAlmostEqual(line.price_subtotal, 2596.0)
-        self.assertAlmostEqual(self._get_component_costs_sum(product_tp), 2596.0)
+        self.assertEqual(self.purchase_order.order_line[0].price_subtotal, 42)
 
     def test_create_non_detailed_price_order_line(self):
-        product_ndtp = self.env.ref("product_pack.product_pack_cpu_non_detailed")
-        line = self.env["purchase.order.line"].create(
-            {
-                "order_id": self.purchase_order.id,
-                "name": product_ndtp.name,
-                "product_id": product_ndtp.id,
-                "product_qty": 1,
-            }
-        )
+        self.pack.pack_type = "non_detailed"
+        self._add_po_line()
         # After create, there will be only one line, because product_type is
         # not a detailed one
-        self.assertEqual(self.purchase_order.order_line, line)
+        self.assertEqual(len(self.purchase_order.order_line), 1)
         # Pack price is equal to the sum of component prices
-        self.assertAlmostEqual(line.price_subtotal, 2596.0)
-        self.assertAlmostEqual(self._get_component_costs_sum(product_ndtp), 2596.0)
+        self.assertEqual(self.purchase_order.order_line.price_subtotal, 42)
 
     def test_update_qty(self):
-        # Ensure the quantities are always updated
-
-        def qty_in_order():
-            return sum(self.purchase_order.order_line.mapped("product_qty"))
-
-        product_cp = self.env.ref("product_pack.product_pack_cpu_detailed_components")
-        main_sol = self.env["purchase.order.line"].create(
-            {
-                "order_id": self.purchase_order.id,
-                "name": product_cp.name,
-                "product_id": product_cp.id,
-                "product_qty": 1,
-            }
-        )
-        total_qty_init = qty_in_order()
-        # change qty of main sol
-        main_sol.product_qty = 2 * main_sol.product_qty
-        total_qty_updated = qty_in_order()
-        # Ensure all quantities have doubled
-        self.assertAlmostEqual(total_qty_init * 2, total_qty_updated)
-
-        # Confirm the purchase
+        pack_line = self._add_po_line()
+        # change qty of main sol and ensure all the quantities have doubled
+        pack_line.product_qty = 2
+        self.assertAlmostEqual(self.purchase_order.order_line[1].product_qty, 4)
+        self.assertAlmostEqual(self.purchase_order.order_line[2].product_qty, 2)
+        # Confirm the sale
         self.purchase_order.button_confirm()
-
         # Ensure we can still update the quantity
-        main_sol.product_qty = 2 * main_sol.product_qty
-        total_qty_confirmed = qty_in_order()
-        self.assertAlmostEqual(total_qty_updated * 2, total_qty_confirmed)
+        pack_line.product_qty = 4
+        self.assertAlmostEqual(self.purchase_order.order_line[1].product_qty, 8)
+        self.assertAlmostEqual(self.purchase_order.order_line[2].product_qty, 4)
 
     def test_do_not_expand(self):
-        product_cp = self.env.ref("product_pack.product_pack_cpu_detailed_components")
-        pack_line = self.env["purchase.order.line"].create(
-            {
-                "order_id": self.purchase_order.id,
-                "name": product_cp.name,
-                "product_id": product_cp.id,
-                "product_qty": 1,
-            }
-        )
-        # After create, there will be four lines
-        self.assertEqual(len(self.purchase_order.order_line), 4)
+        pack_line = self._add_po_line()
         pack_line_update = pack_line.with_context(update_prices=True)
         self.assertTrue(pack_line_update.do_no_expand_pack_lines)
         pack_line_update = pack_line.with_context(update_pricelist=True)
         self.assertTrue(pack_line_update.do_no_expand_pack_lines)
 
     def test_create_several_lines(self):
-        # Create two purchase order lines with two pack products
-        # Check 8 lines are created
+        # Create two sale order lines with two pack products
+        self._add_po_line()
+        self._add_po_line(sequence=20)
+        # Check 6 lines are created
+        self.assertEqual(len(self.purchase_order.order_line), 6)
         # Check lines sequences and order are respected
-        product_cp = self.env.ref("product_pack.product_pack_cpu_detailed_components")
-        product_tp = self.env.ref("product_pack.product_pack_cpu_detailed_ignored")
-        vals = [
-            {
-                "order_id": self.purchase_order.id,
-                "name": product_cp.name,
-                "product_id": product_cp.id,
-                "product_qty": 1,
-            },
-            {
-                "order_id": self.purchase_order.id,
-                "name": product_tp.name,
-                "product_id": product_tp.id,
-                "product_qty": 1,
-            },
-        ]
-        self.env["purchase.order.line"].create(vals)
-        # After create, there will be eight lines (4 + 4)
-        self.assertEqual(len(self.purchase_order.order_line), 8)
-        # Check if lines are well ordered
-        self.assertEqual(self.purchase_order.order_line[0].product_id, product_cp)
-        sequence_cp = self.purchase_order.order_line[0].sequence
-        self.assertEqual(sequence_cp, self.purchase_order.order_line[1].sequence)
-        self.assertEqual(sequence_cp, self.purchase_order.order_line[2].sequence)
-        self.assertEqual(sequence_cp, self.purchase_order.order_line[3].sequence)
-
-        self.assertEqual(self.purchase_order.order_line[4].product_id, product_tp)
-        sequence_tp = self.purchase_order.order_line[4].sequence
-        self.assertEqual(sequence_tp, self.purchase_order.order_line[5].sequence)
-        self.assertEqual(sequence_tp, self.purchase_order.order_line[6].sequence)
-        self.assertEqual(sequence_tp, self.purchase_order.order_line[7].sequence)
+        for po_line in self.purchase_order.order_line[:3]:
+            self.assertEqual(po_line.sequence, 10)
+        for po_line in self.purchase_order.order_line[3:]:
+            self.assertEqual(po_line.sequence, 20)
 
     def test_order_line_detailed_with_seller(self):
-        # Check with detailed options
-        product_cp = self.env.ref("product_pack.product_pack_cpu_detailed_components")
-        product_cp.write(
-            {
-                "seller_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "partner_id": self.env.ref("base.res_partner_12").id,
-                            "min_qty": 1.0,
-                            "price": 25.0,
-                        },
-                    )
-                ]
-            }
-        )
-        product_product_16 = self.env.ref("product.product_product_16")
-        product_product_16.write(
-            {
-                "seller_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "partner_id": self.env.ref("base.res_partner_12").id,
-                            "min_qty": 1.0,
-                            "price": 15.0,
-                        },
-                    )
-                ]
-            }
-        )
-        line = self.env["purchase.order.line"].create(
-            {
-                "order_id": self.purchase_order.id,
-                "name": product_cp.name,
-                "product_id": product_cp.id,
-                "product_qty": 1,
-            }
-        )
+        self.pack.seller_ids = [
+            Command.create({"partner_id": self.partner.id, "min_qty": 1, "price": 25})
+        ]
+        self.component1.seller_ids = [
+            Command.create({"partner_id": self.partner.id, "min_qty": 1, "price": 15})
+        ]
+        self._add_po_line()
         # Check the subtotal corresponding to seller on lines
-        self.assertAlmostEqual(line.price_subtotal, 25.0)
-        self.assertEqual(
-            (self.purchase_order.order_line - line).mapped("price_subtotal"),
-            [1700.0, 15.0, 876.0],
-        )
+        self.assertEqual(self.purchase_order.order_line[0].price_subtotal, 25)
+        # 15 * 2 qty
+        self.assertEqual(self.purchase_order.order_line[1].price_subtotal, 30)
+        self.assertEqual(self.purchase_order.order_line[2].price_subtotal, 18)
 
     def test_order_line_totalized_with_seller(self):
-        product_tp = self.env.ref("product_pack.product_pack_cpu_detailed_totalized")
-        product_product_16 = self.env.ref("product.product_product_16")
-        product_product_16.write(
-            {
-                "seller_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "partner_id": self.env.ref("base.res_partner_12").id,
-                            "min_qty": 1.0,
-                            "price": 15.0,
-                        },
-                    )
-                ]
-            }
-        )
-        line = self.env["purchase.order.line"].create(
-            {
-                "order_id": self.purchase_order.id,
-                "name": product_tp.name,
-                "product_id": product_tp.id,
-                "product_qty": 1,
-            }
-        )
+        self.component1.seller_ids = [
+            Command.create({"partner_id": self.partner.id, "min_qty": 1, "price": 15})
+        ]
+        self.pack.pack_component_price = "totalized"
+        self._add_po_line()
         # Check the subtotal corresponding to seller on lines
-        self.assertAlmostEqual(line.price_subtotal, 2591.0)
-        self.assertAlmostEqual(
-            (self.purchase_order.order_line - line).mapped("price_subtotal"), [0, 0, 0]
-        )
+        # component 1: 15 * 2 qty + component2: 18
+        self.assertEqual(self.purchase_order.order_line[0].price_subtotal, 48)
+        self.assertEqual(self.purchase_order.order_line[1].price_subtotal, 0)
+        self.assertEqual(self.purchase_order.order_line[2].price_subtotal, 0)


### PR DESCRIPTION
Follow-up of #217 and #218

Demo data can make tests to fail in integration environments or locally modified ones, so let's remove them and use data created on the test itself.

We also improve the containerization of the elements of the tests.

In the same movement, we have simplified the code of the test for doing the same with less lines and in a clearer way.

@Tecnativa 