### PR TITLE
[18.0][FIX] product_pack: prevent currency being misinterpreted as UoM when printing labels for totalized packs

### DIFF
--- a/product_pack/models/product_pricelist.py
+++ b/product_pack/models/product_pricelist.py
@@ -25,7 +25,13 @@ class Pricelist(models.Model):
                 ][0]
 
             for line in product.sudo().pack_line_ids:
-                pack_price += line._get_pack_line_price(self, *args, **kwargs)
+                pack_price += line._get_pack_line_price(
+                    self,
+                    kwargs.get("quantity", args[0] if args else 1.0),
+                    uom=kwargs.get("uom"),
+                    date=kwargs.get("date"),
+                    currency=kwargs.get("currency"),
+                )
             return pack_price
         else:
             return super()._get_product_price(product, *args, **kwargs)


### PR DESCRIPTION
Issue:
When printing product labels for pack products with Pack Components Price set to Totalized on the main product, Odoo raised:
AttributeError: 'res.currency' object has no attribute '_compute_quantity'
This happened because in some _get_product_price calls, the currency parameter was being passed as the second positional argument and misinterpreted as uom, causing the crash.

Solution:
Updated _get_product_price to detect when the second positional argument is a res.currency record, move it to kwargs['currency'], and set uom=None. This ensures _compute_price_rule receives the correct parameters and avoids using a currency as a UoM.

Step to reproduce error and test 
1. Create a pack product.
2. Set Pack Components Price to Totalized.
3. Add pack component lines.
4. From the product form, press Print Label. The error should not be appear 

