### PR TITLE
support for Odoo 19

### DIFF
--- a/product_pack/__manifest__.py
+++ b/product_pack/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Product Pack",
-    "version": "18.0.1.0.1",
+    "version": "19.0.1.0.1",
     "category": "Product",
     "summary": "This module allows you to set a product as a Pack",
     "website": "https://github.com/OCA/product-pack",

--- a/product_pack/views/product_template_views.xml
+++ b/product_pack/views/product_template_views.xml
@@ -8,12 +8,10 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
-            <div name="options" position="inside">
-                <div>
-                    <field name="pack_ok" />
-                    <label for="pack_ok" />
-                </div>
-            </div>
+            <!-- Add pack field in a more robust way for Odoo 19 compatibility -->
+            <field name="type" position="after">
+                <field name="pack_ok" />
+            </field>
             <notebook position="inside">
                 <page name="page_pack" string="Pack" invisible="not pack_ok">
                     <group name="group_pack">

--- a/purchase_product_pack/__manifest__.py
+++ b/purchase_product_pack/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 {
     "name": "Purchase Product Pack",
-    "version": "18.0.1.0.1",
+    "version": "19.0.1.0.1",
     "category": "Purchase",
     "summary": "This module allows you to buy product packs",
     "website": "https://github.com/OCA/product-pack",

--- a/sale_product_pack/__manifest__.py
+++ b/sale_product_pack/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Sale Product Pack",
-    "version": "18.0.1.0.2",
+    "version": "19.0.1.0.2",
     "category": "Sales",
     "summary": "This module allows you to sell product packs",
     "website": "https://github.com/OCA/product-pack",

--- a/sale_stock_product_pack/__manifest__.py
+++ b/sale_stock_product_pack/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Sale Stock Product Pack",
     "summary": "Compatibility module for packs that are storable products",
-    "version": "18.0.1.0.1",
+    "version": "19.0.1.0.1",
     "development_status": "Beta",
     "category": "Sale",
     "website": "https://github.com/OCA/product-pack",

--- a/stock_product_pack/__manifest__.py
+++ b/stock_product_pack/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Stock product Pack",
-    "version": "18.0.1.0.0",
+    "version": "19.0.1.0.0",
     "category": "Warehouse",
     "summary": "This module allows you to get the right available quantities "
     "of the packs",


### PR DESCRIPTION
The "is a pack" option did not show up in Odoo 19 due to UI changes. It has been fixed to show up now in Odoo 19.