### PR TITLE
[IMP] stock_product_pack: Extract pack move removal check into method

### DIFF
--- a/stock_product_pack/models/stock_rule.py
+++ b/stock_product_pack/models/stock_rule.py
@@ -6,18 +6,21 @@ from odoo import api, models
 class ProcurementGroup(models.Model):
     _inherit = "procurement.group"
 
+    def is_pack_dont_create_move(self, product):
+        return (
+            product
+            and product.pack_ok
+            and product.dont_create_move
+            and product.pack_type == "detailed"
+        )
+
     @api.model
     def run(self, procurements, raise_user_error=True):
         """If 'run' is called on a pack product storable.
         we remove the procurement with this product pack.
         """
         for procurement in procurements:
-            if (
-                procurement.product_id
-                and procurement.product_id.pack_ok
-                and procurement.product_id.dont_create_move
-                and procurement.product_id.pack_type == "detailed"
-            ):
+            if self.is_pack_dont_create_move(procurement.product_id):
                 procurements.remove(procurement)
 
         return super().run(procurements, raise_user_error=raise_user_error)

--- a/stock_product_pack/tests/test_stock_product_pack.py
+++ b/stock_product_pack/tests/test_stock_product_pack.py
@@ -178,6 +178,37 @@ class TestStockProductPack(TransactionCase):
         self.assertEqual(self.pack_dc.virtual_available, 5)
         self.assertEqual(self.pack_dc.qty_available, 5)
 
+    def test_is_pack_dont_create_move(self):
+        procurement_group = self.env["procurement.group"]
+        category_all_id = self.env.ref("product.product_category_all").id
+
+        self.assertTrue(
+            procurement_group.is_pack_dont_create_move(self.pack_dc_with_dm)
+        )
+        self.assertFalse(procurement_group.is_pack_dont_create_move(self.pack_dc))
+
+        non_detailed_pack = self.product_obj.create(
+            {
+                "name": "Non-detailed pack with don't create move",
+                "detailed_type": "product",
+                "pack_ok": True,
+                "dont_create_move": True,
+                "pack_type": "non_detailed",
+                "categ_id": category_all_id,
+            }
+        )
+        self.assertFalse(procurement_group.is_pack_dont_create_move(non_detailed_pack))
+
+        not_a_pack = self.product_obj.create(
+            {
+                "name": "Not a pack with don't create move",
+                "detailed_type": "product",
+                "dont_create_move": True,
+                "categ_id": category_all_id,
+            }
+        )
+        self.assertFalse(procurement_group.is_pack_dont_create_move(not_a_pack))
+
     def test_pack_with_dont_move_the_parent(self):
         """Run a procurement for prod pack products when there are only 5 in stock then
         check that MTO is applied on the moves when the rule is set to 'mts_else_mto'


### PR DESCRIPTION
Extract the logic for checking if a product should be removed from procurements into a dedicated method `is_pack_dont_create_move`.

This improves code readability and maintainability by encapsulating the complex condition. 