### PR TITLE
[12.0][FIX] product_pack: fix wrong digits reference on pack line quantity

### DIFF
--- a/product_pack/__manifest__.py
+++ b/product_pack/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     'name': 'Product Pack',
-    'version': '12.0.1.0.2',
+    'version': '12.0.1.0.3',
     'category': 'Product',
     'summary': 'This module allows you to set a product as a Pack',
     'website': 'https://github.com/OCA/product-pack',

--- a/product_pack/models/product_pack_line.py
+++ b/product_pack/models/product_pack_line.py
@@ -21,7 +21,7 @@ class ProductPackLine(models.Model):
     quantity = fields.Float(
         required=True,
         default=1.0,
-        digits=dp.get_precision('Product UoS'),
+        digits=dp.get_precision('Product Unit of Measure'),
     )
     product_id = fields.Many2one(
         'product.product',


### PR DESCRIPTION
## Summary
- Replace non-existent "Product UoS" digits reference with "Product Unit of Measure" on product.pack.line quantity field
- Bump version to 12.0.1.0.3

Closes #245