### PR TITLE
[14.0][FIX] product_pack: fix wrong digits reference on pack line quantity

### DIFF
--- a/product_pack/__manifest__.py
+++ b/product_pack/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Product Pack",
-    "version": "14.0.1.1.2",
+    "version": "14.0.1.1.3",
     "category": "Product",
     "summary": "This module allows you to set a product as a Pack",
     "website": "https://github.com/OCA/product-pack",

--- a/product_pack/models/product_pack_line.py
+++ b/product_pack/models/product_pack_line.py
@@ -20,7 +20,7 @@ class ProductPackLine(models.Model):
     quantity = fields.Float(
         required=True,
         default=1.0,
-        digits="Product UoS",
+        digits="Product Unit of Measure",
     )
     product_id = fields.Many2one(
         "product.product",

--- a/product_pack/static/description/index.html
+++ b/product_pack/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -471,7 +472,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
## Summary
- Replace non-existent "Product UoS" digits reference with "Product Unit of Measure" on product.pack.line quantity field
- Bump version to 14.0.1.1.3

Closes #245