### PR TITLE
[19.0][FIX] product_pack: align pack_ok checkbox with other product checks

### DIFF
--- a/product_pack/views/product_template_views.xml
+++ b/product_pack/views/product_template_views.xml
@@ -9,10 +9,10 @@
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
             <div name="options" position="inside">
-                <div>
+                <span>
                     <field name="pack_ok" />
                     <label for="pack_ok" />
-                </div>
+                </span>
             </div>
             <notebook position="inside">
                 <page name="page_pack" string="Pack" invisible="not pack_ok">


### PR DESCRIPTION
The `pack_ok` boolean field was wrapped in a `<div>` (block element)
inside the `options` area of the product form. This caused it to render
on its own line instead of inline with the other boolean options
(Sales, Purchases, POS, etc.).

Replace `<div>` with `<span>` so the checkbox renders inline, consistent
with the rest of the product header options.