### PR TITLE
[16.0][IMP+FIX] sale_stock_product_pack + stock_product_pack: Display Delivery Slip data correctly sorted in pack products

### DIFF
--- a/sale_stock_product_pack/models/stock_move_line.py
+++ b/sale_stock_product_pack/models/stock_move_line.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2024-2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models
@@ -7,51 +7,9 @@ from odoo import models
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    # TODO: Check if it is possible to remove it
-    def _get_aggregated_product_quantities(self, **kwargs):
-        """If any product pack has been used and is consumable we must reorder.
-        Example of picking:
-        - Consumable product (pack): sequence 10 (stock.move, id=1)
-        - Storable product A: sequence 11 (stock.move, id=2)
-        - Storable product B: sequence 12 (stock.move, id=3)
-        Confirm picking (Storable products have stock) and we get the following:
-        - stock.move.line, id=1, move_id=2 (Storable product A)
-        - stock.move.line, id=2, move_id=3 (Storable product B)
-        - stock.move.line, id=3, move_id=1 (Consumable product (pack))
-        Done picking and print Delivery Slip report, this method is used to print table,
-        and we get a confusing order, so we must reorder them according to the sequence
-        of the linked stock.move.
-        This is a known side effect in the stock addon when using consumable product +
-        storable products but for now we only reorder for product packs.
-        """
-        if any(
-            sml.move_id.sale_line_id
-            and sml.product_id.pack_ok
-            and sml.product_id.detailed_type == "consu"
-            for sml in self
-        ):
-            ordered_self = self.env["stock.move.line"]
-            for item in self:
-                if item in ordered_self:
-                    continue
-                ppl = item.move_id.sale_line_id.pack_parent_line_id
-                if (
-                    ppl
-                    and ppl.product_id.pack_ok
-                    and ppl.product_id.detailed_type == "consu"
-                ):
-                    # First add sml from product pack
-                    ordered_self += self.filtered(
-                        lambda x: x.product_id == ppl.product_id
-                    )
-                    # After add sml records from pack_child_line_ids
-                    for line in ppl.pack_child_line_ids:
-                        ordered_self += self.filtered(
-                            lambda x: x.product_id == line.product_id
-                        )
-                    continue
-                ordered_self += item
-            return super(
-                StockMoveLine, ordered_self
-            )._get_aggregated_product_quantities(**kwargs)
-        return super()._get_aggregated_product_quantities(**kwargs)
+    def _get_aggregated_properties(self, move_line=False, move=False):
+        result = super()._get_aggregated_properties(move_line, move)
+        move = result["move"]
+        if move.sale_line_id and move.sale_line_id.pack_parent_line_id:
+            result["line_key"] += f"_{move.sale_line_id.id}"
+        return result

--- a/sale_stock_product_pack/tests/test_sale_stock_product_pack.py
+++ b/sale_stock_product_pack/tests/test_sale_stock_product_pack.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Tecnativa - David Vidal
-# Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2024-2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import Command
 from odoo.tests import Form
 
 from odoo.addons.base.tests.common import BaseCommon
@@ -38,26 +39,23 @@ class TestSaleStockProductPack(BaseCommon):
                 "pack_component_price": "detailed",
                 "categ_id": cls.category_all.id,
                 "pack_line_ids": [
-                    (
-                        0,
-                        0,
+                    Command.create(
                         {"product_id": cls.component_1.id, "quantity": 1},
                     ),
-                    (
-                        0,
-                        0,
+                    Command.create(
                         {"product_id": cls.component_2.id, "quantity": 1},
                     ),
                 ],
             }
         )
 
-    def _create_sale_order(self, product, qty):
+    def _create_sale_order(self, lines):
         sale_form = Form(self.env["sale.order"])
         sale_form.partner_id = self.partner
-        with sale_form.order_line.new() as line:
-            line.product_id = product
-            line.product_uom_qty = qty
+        for line_data in lines:
+            with sale_form.order_line.new() as line:
+                line.product_id = line_data[0]
+                line.product_uom_qty = line_data[1]
         return sale_form.save()
 
     def _create_stock_quant(self, product, qty):
@@ -73,9 +71,8 @@ class TestSaleStockProductPack(BaseCommon):
         self.product_pack.type = "product"
         self.product_pack.invoice_policy = "delivery"
         self.product_pack.pack_line_ids.product_id.invoice_policy = "delivery"
-        sale = self._create_sale_order(self.product_pack, 9)
+        sale = self._create_sale_order([(self.product_pack, 9)])
         sale.action_confirm()
-
         pack_line = sale.order_line.filtered(
             lambda x: x.product_id == self.product_pack
         )
@@ -91,8 +88,22 @@ class TestSaleStockProductPack(BaseCommon):
         sale.order_line.mapped("qty_delivered")
         self.assertEqual(9, pack_line.qty_delivered)
 
-    def test_picking_pack_consu(self):
-        sale = self._create_sale_order(self.product_pack, 1)
+    def _get_aggregated_product_quantities(self, sol):
+        sol_data = sol.move_ids.move_line_ids._get_aggregated_product_quantities()
+        key_0 = list(sol_data.keys())[0]
+        return sol_data[key_0]
+
+    def test_picking_pack_consu_01(self):
+        sale = self._create_sale_order([(self.product_pack, 1)])
+        sol_product_pack = sale.order_line.filtered(
+            lambda x: x.product_id == self.product_pack
+        )
+        sol_component_1 = sale.order_line.filtered(
+            lambda x: x.product_id == self.component_1
+        )
+        sol_component_2 = sale.order_line.filtered(
+            lambda x: x.product_id == self.component_2
+        )
         self._create_stock_quant(self.component_1, 1)
         self._create_stock_quant(self.component_2, 1)
         sale.action_confirm()
@@ -108,3 +119,79 @@ class TestSaleStockProductPack(BaseCommon):
         self.assertEqual(
             data_names, ["Pack (consumable)", "Component 1", "Component 2"]
         )
+        line_product_pack_data = self._get_aggregated_product_quantities(
+            sol_product_pack
+        )
+        self.assertEqual(line_product_pack_data["qty_ordered"], 1)
+        self.assertEqual(line_product_pack_data["qty_done"], 1)
+        line_component_1_data = self._get_aggregated_product_quantities(sol_component_1)
+        self.assertEqual(line_component_1_data["qty_ordered"], 1)
+        self.assertEqual(line_component_1_data["qty_done"], 1)
+        line_component_2_data = self._get_aggregated_product_quantities(sol_component_2)
+        self.assertEqual(line_component_2_data["qty_ordered"], 1)
+        self.assertEqual(line_component_2_data["qty_done"], 1)
+
+    def test_picking_pack_consu_02(self):
+        sale = self._create_sale_order(
+            [(self.component_1, 1), (self.component_2, 10), (self.product_pack, 2)]
+        )
+        sol_component_1 = sale.order_line.filtered(
+            lambda x: x.product_id == self.component_1 and not x.pack_parent_line_id
+        )
+        sol_component_2 = sale.order_line.filtered(
+            lambda x: x.product_id == self.component_2 and not x.pack_parent_line_id
+        )
+        sol_product_pack = sale.order_line.filtered(
+            lambda x: x.product_id == self.product_pack
+        )
+        sol_product_pack_component_1 = sale.order_line.filtered(
+            lambda x: x.pack_parent_line_id == sol_product_pack
+            and x.product_id == self.component_1
+        )
+        sol_product_pack_component_2 = sale.order_line.filtered(
+            lambda x: x.pack_parent_line_id == sol_product_pack
+            and x.product_id == self.component_2
+        )
+        self._create_stock_quant(self.component_1, 3)
+        self._create_stock_quant(self.component_2, 12)
+        sale.action_confirm()
+        picking = sale.picking_ids
+        res = picking.button_validate()
+        wizard = self.env[res["res_model"]].with_context(**res["context"]).create({})
+        wizard.process()
+        self.assertEqual(picking.state, "done")
+        data_names = []
+        aggregated_lines = picking.move_line_ids._get_aggregated_product_quantities()
+        for line in aggregated_lines:
+            data_names.append(aggregated_lines[line]["name"])
+        self.assertEqual(
+            data_names,
+            [
+                "Component 1",
+                "Component 2",
+                "Pack (consumable)",
+                "Component 1",
+                "Component 2",
+            ],
+        )
+        line_component_1_data = self._get_aggregated_product_quantities(sol_component_1)
+        self.assertEqual(line_component_1_data["qty_ordered"], 1)
+        self.assertEqual(line_component_1_data["qty_done"], 1)
+        line_component_2_data = self._get_aggregated_product_quantities(sol_component_2)
+        self.assertEqual(line_component_2_data["qty_ordered"], 10)
+        self.assertEqual(line_component_2_data["qty_done"], 10)
+        line_product_pack_data = self._get_aggregated_product_quantities(
+            sol_product_pack
+        )
+        self.assertEqual(line_product_pack_data["qty_ordered"], 2)
+        self.assertEqual(line_product_pack_data["qty_done"], 2)
+        line_product_pack_component_1_data = self._get_aggregated_product_quantities(
+            sol_product_pack_component_1
+        )
+        self.assertEqual(line_product_pack_component_1_data["qty_ordered"], 2)
+        self.assertEqual(line_product_pack_component_1_data["qty_done"], 2)
+        line_product_pack_component_2_data = self._get_aggregated_product_quantities(
+            sol_product_pack_component_2
+        )
+        self.assertEqual(line_product_pack_component_2_data["qty_ordered"], 2)
+        self.assertEqual(line_product_pack_component_2_data["qty_done"], 2)

--- a/stock_product_pack/models/__init__.py
+++ b/stock_product_pack/models/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import product_template
 from . import product_product
+from . import stock_move_line
 from . import stock_rule

--- a/stock_product_pack/models/stock_move_line.py
+++ b/stock_product_pack/models/stock_move_line.py
@@ -1,0 +1,32 @@
+# Copyright 2024-2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    # TODO: Check if it is possible to remove it
+    def _get_aggregated_product_quantities(self, **kwargs):
+        """If any product pack has been used and is consumable we must reorder.
+        Example of picking:
+        - Consumable product (pack): sequence 10 (stock.move, id=1)
+        - Storable product A: sequence 11 (stock.move, id=2)
+        - Storable product B: sequence 12 (stock.move, id=3)
+        Confirm picking (Storable products have stock) and we get the following:
+        - stock.move.line, id=1, move_id=2 (Storable product A)
+        - stock.move.line, id=2, move_id=3 (Storable product B)
+        - stock.move.line, id=3, move_id=1 (Consumable product (pack))
+        Done picking and print Delivery Slip report, this method is used to print table,
+        and we get a confusing order, so we must reorder them according to the sequence
+        of the linked stock.move.
+        This is a known side effect in the stock addon when using consumable product +
+        storable products but for now we only reorder for product packs.
+        """
+        if any(
+            sml.product_id.pack_ok and sml.product_id.detailed_type == "consu"
+            for sml in self
+        ):
+            self = self.move_id.sorted().move_line_ids
+        return super()._get_aggregated_product_quantities(**kwargs)


### PR DESCRIPTION
Display Delivery Slip data correctly sorted in pack products

Related to https://github.com/OCA/product-pack/pull/182/changes/63e445ac02276bcbd2cd44a74e1457b5cb4c05cf + https://github.com/OCA/product-pack/pull/253

Changes done:
- [x] The `_get_aggregated_product_quantities()` method has been simplified; if there are any "pack moves", the `stock.move.line` records are sorted according to the `stock.move` order so that the data appears in the correct order
- [x] The `_get_aggregated_product_quantities()` method has been moved to `stock_product_pack` so that it works in all cases (sales and purchases)
- [x] The `_get_aggregated_properties()` method is overridden to specify a different `line_key`, ensuring that data is not incorrectly grouped if there are extra lines using any of the products contained in the pack
- [x] Tests have been added to cover more complex use cases (component1 + component2 + product_pack) data

This same approach (the `_get_aggregated_properties()` method) could be used in a `purchase_stock_product_pack` module

Please @pedrobaeza and @eduezerouali-tecnativa can you review it?

@Tecnativa TT62930 TT62189