### PR TITLE
[19.0][IMP] stock_product_pack + sale_stock_product_pack: Display Delivery Slip data correctly in pack products

### DIFF
--- a/product_pack/tests/common.py
+++ b/product_pack/tests/common.py
@@ -2,10 +2,11 @@
 # Copyright 2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo import Command
-from odoo.tests import TransactionCase
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class ProductPackCommon(TransactionCase):
+class ProductPackCommon(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/sale_stock_product_pack/models/__init__.py
+++ b/sale_stock_product_pack/models/__init__.py
@@ -1,1 +1,2 @@
 from . import sale_order
+from . import stock_move_line

--- a/sale_stock_product_pack/models/stock_move_line.py
+++ b/sale_stock_product_pack/models/stock_move_line.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def _get_aggregated_properties(self, move_line=False, move=False):
+        # It is important to set a specific line_key if any of the lines are linked to
+        # a sale and are part of a pack, to prevent the data from being added to any
+        # additional lines that order may have for that product
+        result = super()._get_aggregated_properties(move_line, move)
+        move = result["move"]
+        if move.sale_line_id and move.sale_line_id.pack_parent_line_id:
+            result["line_key"] += f"_{move.sale_line_id.pack_parent_line_id.id}"
+        return result

--- a/sale_stock_product_pack/tests/test_sale_stock_product_pack.py
+++ b/sale_stock_product_pack/tests/test_sale_stock_product_pack.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Tecnativa - David Vidal
 # Copyright 2025 Tecnativa - Pedro M. Baeza
+# Copyright 2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.addons.sale_product_pack.tests.common import TestSaleProductPackBase
 
@@ -8,9 +9,21 @@ class TestSaleStockProductPack(TestSaleProductPackBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.warehouse = cls.env["stock.warehouse"].search(
+            [("company_id", "=", cls.env.company.id)], limit=1
+        )
         cls.pack.type = "consu"
         cls.pack.invoice_policy = "delivery"
         cls.pack.pack_line_ids.product_id.invoice_policy = "delivery"
+
+    def _create_stock_quant(self, product, qty):
+        self.env["stock.quant"].create(
+            {
+                "product_id": product.id,
+                "location_id": self.warehouse.lot_stock_id.id,
+                "quantity": qty,
+            }
+        )
 
     def test_delivered_quantities(self):
         pack_line = self._add_so_line()
@@ -27,3 +40,99 @@ class TestSaleStockProductPack(TestSaleProductPackBase):
         self.sale.picking_ids._action_done()
         # All components delivered, all the pack quantities should be so
         self.assertEqual(9, pack_line.qty_delivered)
+
+    def _get_aggregated_product_quantities(self, sol):
+        sol_data = sol.move_ids.move_line_ids._get_aggregated_product_quantities()
+        key_0 = list(sol_data.keys())[0]
+        return sol_data[key_0]
+
+    def test_picking_pack_consu_01(self):
+        self.pack.pack_type = "detailed"
+        self.component1.is_storable = True
+        self.component2.is_storable = True
+        sol_pack = self._add_so_line(self.pack)
+        self._create_stock_quant(self.component1, 2)
+        self._create_stock_quant(self.component2, 1)
+        self.sale_order.action_confirm()
+        sol_component1 = self.sale_order.order_line.filtered(
+            lambda x: x.product_id == self.component1
+        )
+        sol_component2 = self.sale_order.order_line.filtered(
+            lambda x: x.product_id == self.component2
+        )
+        picking = self.sale_order.picking_ids
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+        data_names = []
+        aggregated_lines = picking.move_line_ids._get_aggregated_product_quantities()
+        for line in aggregated_lines:
+            data_names.append(aggregated_lines[line]["name"])
+        self.assertEqual(
+            data_names, ["Test product pack", "Pack component 1", "Pack component 2"]
+        )
+        line_product_pack_data = self._get_aggregated_product_quantities(sol_pack)
+        self.assertEqual(line_product_pack_data["qty_ordered"], 1)
+        self.assertEqual(line_product_pack_data["quantity"], 1)
+        line_component1_data = self._get_aggregated_product_quantities(sol_component1)
+        self.assertEqual(line_component1_data["qty_ordered"], 2)
+        self.assertEqual(line_component1_data["quantity"], 2)
+        line_component2_data = self._get_aggregated_product_quantities(sol_component2)
+        self.assertEqual(line_component2_data["qty_ordered"], 1)
+        self.assertEqual(line_component2_data["quantity"], 1)
+
+    def test_picking_pack_consu_02(self):
+        self.pack.pack_type = "detailed"
+        self.component1.is_storable = True
+        self.component2.is_storable = True
+        sol_component1 = self._add_so_line(self.component1, 10)
+        sol_component2 = self._add_so_line(self.component2, 11)
+        sol_component2.product_uom_qty = 10
+        sol_pack = self._add_so_line(self.pack, 12)
+        sol_pack.product_uom_qty = 2
+        self._create_stock_quant(self.component1, 5)  # 1 + (2*2)
+        self._create_stock_quant(self.component2, 12)
+        self.sale_order.action_confirm()
+        sol_pack_component1 = self.sale_order.order_line.filtered(
+            lambda x: x.pack_parent_line_id == sol_pack
+            and x.product_id == self.component1
+        )
+        sol_pack_component2 = self.sale_order.order_line.filtered(
+            lambda x: x.pack_parent_line_id == sol_pack
+            and x.product_id == self.component2
+        )
+        picking = self.sale_order.picking_ids
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+        data_names = []
+        aggregated_lines = picking.move_line_ids._get_aggregated_product_quantities()
+        for line in aggregated_lines:
+            data_names.append(aggregated_lines[line]["name"])
+        self.assertEqual(
+            data_names,
+            [
+                "Pack component 1",
+                "Pack component 2",
+                "Test product pack",
+                "Pack component 1",
+                "Pack component 2",
+            ],
+        )
+        line_component1_data = self._get_aggregated_product_quantities(sol_component1)
+        self.assertEqual(line_component1_data["qty_ordered"], 1)
+        self.assertEqual(line_component1_data["quantity"], 1)
+        line_component2_data = self._get_aggregated_product_quantities(sol_component2)
+        self.assertEqual(line_component2_data["qty_ordered"], 10)
+        self.assertEqual(line_component2_data["quantity"], 10)
+        line_pack_data = self._get_aggregated_product_quantities(sol_pack)
+        self.assertEqual(line_pack_data["qty_ordered"], 2)
+        self.assertEqual(line_pack_data["quantity"], 2)
+        line_pack_component1_data = self._get_aggregated_product_quantities(
+            sol_pack_component1
+        )
+        self.assertEqual(line_pack_component1_data["qty_ordered"], 4)
+        self.assertEqual(line_pack_component1_data["quantity"], 4)
+        line_pack_component2_data = self._get_aggregated_product_quantities(
+            sol_pack_component2
+        )
+        self.assertEqual(line_pack_component2_data["qty_ordered"], 2)
+        self.assertEqual(line_pack_component2_data["quantity"], 2)

--- a/stock_product_pack/README.rst
+++ b/stock_product_pack/README.rst
@@ -79,16 +79,16 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Ernesto Tejeda
-  - Pedro M. Baeza
-  - Sergio Teruel
-  - João Marques
+   -  Ernesto Tejeda
+   -  Pedro M. Baeza
+   -  Sergio Teruel
+   -  João Marques
 
-- `ADHOC SA <https://www.adhoc.com.ar>`__:
+-  `ADHOC SA <https://www.adhoc.com.ar>`__:
 
-  - Bruno Zanotti
+   -  Bruno Zanotti
 
 Maintainers
 -----------
@@ -103,13 +103,13 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-.. |maintainer-ernestotejeda| image:: https://github.com/ernestotejeda.png?size=40px
-    :target: https://github.com/ernestotejeda
-    :alt: ernestotejeda
+.. |maintainer-victoralmau| image:: https://github.com/victoralmau.png?size=40px
+    :target: https://github.com/victoralmau
+    :alt: victoralmau
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-ernestotejeda| 
+|maintainer-victoralmau| 
 
 This module is part of the `OCA/product-pack <https://github.com/OCA/product-pack/tree/19.0/stock_product_pack>`_ project on GitHub.
 

--- a/stock_product_pack/__manifest__.py
+++ b/stock_product_pack/__manifest__.py
@@ -11,7 +11,7 @@
     "of the packs",
     "website": "https://github.com/OCA/product-pack",
     "author": "NaN·tic, ADHOC SA, Tecnativa, Odoo Community Association (OCA)",
-    "maintainers": ["ernestotejeda"],
+    "maintainers": ["victoralmau"],
     "license": "AGPL-3",
     "depends": ["product_pack", "stock"],
     "data": ["security/ir.model.access.csv", "views/product_template_views.xml"],

--- a/stock_product_pack/models/__init__.py
+++ b/stock_product_pack/models/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import product_template
 from . import product_product
+from . import stock_move_line
 from . import stock_rule

--- a/stock_product_pack/models/stock_move_line.py
+++ b/stock_product_pack/models/stock_move_line.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    # TODO: Check if it is possible to remove it
+    def _get_aggregated_product_quantities(self, **kwargs):
+        """If any product pack has been used and is consumable we must reorder.
+        Example of picking:
+        - Consumable product (pack): sequence 10 (stock.move, id=1)
+        - Storable product A: sequence 11 (stock.move, id=2)
+        - Storable product B: sequence 12 (stock.move, id=3)
+        Confirm picking (Storable products have stock) and we get the following:
+        - stock.move.line, id=1, move_id=2 (Storable product A)
+        - stock.move.line, id=2, move_id=3 (Storable product B)
+        - stock.move.line, id=3, move_id=1 (Consumable product (pack))
+        Done picking and print Delivery Slip report, this method is used to print table,
+        and we get a confusing order, so we must reorder them according to the sequence
+        of the linked stock.move.
+        This is a known side effect in the stock addon when using consumable product +
+        storable products but for now we only reorder for product packs.
+        """
+        if any(
+            sml.product_id.pack_ok and sml.product_id.type == "consu" for sml in self
+        ):
+            self = self.move_id.sorted().move_line_ids
+        return super()._get_aggregated_product_quantities(**kwargs)

--- a/stock_product_pack/static/description/index.html
+++ b/stock_product_pack/static/description/index.html
@@ -450,7 +450,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/ernestotejeda"><img alt="ernestotejeda" src="https://github.com/ernestotejeda.png?size=40px" /></a></p>
+<p><a class="reference external image-reference" href="https://github.com/victoralmau"><img alt="victoralmau" src="https://github.com/victoralmau.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/product-pack/tree/19.0/stock_product_pack">OCA/product-pack</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/stock_product_pack/tests/test_stock_product_pack.py
+++ b/stock_product_pack/tests/test_stock_product_pack.py
@@ -90,7 +90,7 @@ class TestStockProductPack(TransactionCase):
             }
         )
         warehouse = cls.env["stock.warehouse"].search(
-            [("company_id", "=", cls.env.user.id)], limit=1
+            [("company_id", "=", cls.env.company.id)], limit=1
         )
         cls.stock_rule = cls.stock_rule_obj.create(
             {

--- a/stock_product_pack/tests/test_stock_product_pack.py
+++ b/stock_product_pack/tests/test_stock_product_pack.py
@@ -137,6 +137,52 @@ class TestStockProductPack(BaseCommon):
         self.assertEqual(self.pack_dc.virtual_available, 5)
         self.assertEqual(self.pack_dc.qty_available, 5)
 
+    def _create_stock_quant(self, product, qty):
+        self.env["stock.quant"].create(
+            {
+                "product_id": product.id,
+                "location_id": self.warehouse.lot_stock_id.id,
+                "quantity": qty,
+            }
+        )
+
+    def test_picking_pack_consu(self):
+        # Simulate the out picking that would be generated
+        self.pack_dc.pack_type = "detailed"
+        self.component_1.is_storable = True
+        self.component_2.is_storable = True
+        self.component_3.is_storable = True
+        self.component_4.is_storable = True
+        self._create_stock_quant(self.component_1, 1)
+        self._create_stock_quant(self.component_2, 1)
+        self._create_stock_quant(self.component_3, 1)
+        self._create_stock_quant(self.component_4, 1)
+        moves_data = [
+            (self.pack_dc, 1),
+            (self.component_1, 1),
+            (self.component_2, 1),
+            (self.component_3, 1),
+            (self.component_4, 1),
+        ]
+        picking = self._create_picking(self.warehouse.out_type_id.id, moves_data)
+        picking.action_confirm()
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+        data_names = []
+        aggregated_lines = picking.move_line_ids._get_aggregated_product_quantities()
+        for line in aggregated_lines:
+            data_names.append(aggregated_lines[line]["name"])
+        self.assertEqual(
+            data_names,
+            [
+                "Pack",
+                "Component 1",
+                "Component 2",
+                "Component 3",
+                "Component 4",
+            ],
+        )
+
     def test_pack_with_dont_move_the_parent(self):
         """Run a procurement for prod pack products when there are only 5 in stock then
         check that MTO is applied on the moves when the rule is set to 'mts_else_mto'

--- a/stock_product_pack/tests/test_stock_product_pack.py
+++ b/stock_product_pack/tests/test_stock_product_pack.py
@@ -1,16 +1,15 @@
 # Copyright 2019 Tecnativa - Ernesto Tejeda
 # Copyright 2020 Tecnativa - João Marques
+# Copyright 2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import Command
+from odoo.tests import Form, tagged
 
-import logging
-
-from odoo.tests import Form, TransactionCase, tagged
-
-_logger = logging.getLogger(__name__)
+from odoo.addons.base.tests.common import BaseCommon
 
 
 @tagged("post_install", "-at_install")
-class TestStockProductPack(TransactionCase):
+class TestStockProductPack(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -22,11 +21,10 @@ class TestStockProductPack(TransactionCase):
         )
         category_all_id = category.id
         cls.product_obj = cls.env["product.product"]
-        cls.stock_rule_obj = cls.env["stock.rule"]
         # The model stock doesn't add anymore the 'product'
         # selection to the product type.
         # Thus the type is changed to 'consu'
-        component_1 = cls.product_obj.create(
+        cls.component_1 = cls.product_obj.create(
             {
                 "name": "Component 1",
                 "type": "consu",
@@ -34,7 +32,7 @@ class TestStockProductPack(TransactionCase):
                 "categ_id": category_all_id,
             }
         )
-        component_2 = cls.product_obj.create(
+        cls.component_2 = cls.product_obj.create(
             {
                 "name": "Component 2",
                 "type": "consu",
@@ -42,14 +40,14 @@ class TestStockProductPack(TransactionCase):
                 "categ_id": category_all_id,
             }
         )
-        component_3 = cls.product_obj.create(
+        cls.component_3 = cls.product_obj.create(
             {
                 "name": "Component 3",
                 "type": "service",
                 "categ_id": category_all_id,
             }
         )
-        component_4 = cls.product_obj.create(
+        cls.component_4 = cls.product_obj.create(
             {
                 "name": "Component 4",
                 "type": "consu",
@@ -66,42 +64,23 @@ class TestStockProductPack(TransactionCase):
                 "pack_component_price": "detailed",
                 "categ_id": category_all_id,
                 "pack_line_ids": [
-                    (
-                        0,
-                        0,
-                        {"product_id": component_1.id, "quantity": 1},
+                    Command.create(
+                        {"product_id": cls.component_1.id, "quantity": 1},
                     ),
-                    (
-                        0,
-                        0,
-                        {"product_id": component_2.id, "quantity": 1},
+                    Command.create(
+                        {"product_id": cls.component_2.id, "quantity": 1},
                     ),
-                    (
-                        0,
-                        0,
-                        {"product_id": component_3.id, "quantity": 1},
+                    Command.create(
+                        {"product_id": cls.component_3.id, "quantity": 1},
                     ),
-                    (
-                        0,
-                        0,
-                        {"product_id": component_4.id, "quantity": 1},
+                    Command.create(
+                        {"product_id": cls.component_4.id, "quantity": 1},
                     ),
                 ],
             }
         )
-        warehouse = cls.env["stock.warehouse"].search(
+        cls.warehouse = cls.env["stock.warehouse"].search(
             [("company_id", "=", cls.env.company.id)], limit=1
-        )
-        cls.stock_rule = cls.stock_rule_obj.create(
-            {
-                "name": "Stock to Costumers",
-                "action": "pull",
-                "picking_type_id": cls.env.ref("stock.picking_type_internal").id,
-                "route_id": cls.env.ref("stock.route_warehouse0_mto").id,
-                "procure_method": "make_to_stock",
-                "warehouse_id": warehouse.id,
-                "location_dest_id": cls.env.ref("stock.stock_location_stock").id,
-            }
         )
         cls.pack_dc_with_dm = cls.product_obj.create(
             {
@@ -113,87 +92,48 @@ class TestStockProductPack(TransactionCase):
                 "pack_component_price": "detailed",
                 "categ_id": category_all_id,
                 "pack_line_ids": [
-                    (
-                        0,
-                        0,
-                        {"product_id": component_1.id, "quantity": 1},
+                    Command.create(
+                        {"product_id": cls.component_1.id, "quantity": 1},
                     ),
-                    (
-                        0,
-                        0,
-                        {"product_id": component_2.id, "quantity": 1},
+                    Command.create(
+                        {"product_id": cls.component_2.id, "quantity": 1},
                     ),
-                    (
-                        0,
-                        0,
-                        {"product_id": component_3.id, "quantity": 1},
+                    Command.create(
+                        {"product_id": cls.component_3.id, "quantity": 1},
                     ),
-                    (
-                        0,
-                        0,
-                        {"product_id": component_4.id, "quantity": 1},
+                    Command.create(
+                        {"product_id": cls.component_4.id, "quantity": 1},
                     ),
                 ],
             }
         )
+        cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
+
+    def _create_picking(self, picking_type_id, moves_data):
+        picking_form = Form(
+            self.env["stock.picking"].with_context(
+                default_picking_type_id=picking_type_id,
+            )
+        )
+        picking_form.partner_id = self.partner
+        for move_data in moves_data:
+            with picking_form.move_ids.new() as move:
+                move.product_id = move_data[0]
+                move.product_uom_qty = move_data[1]
+        return picking_form.save()
 
     def test_compute_quantities_dict(self):
-        location_id = (self.env.ref("stock.stock_location_suppliers").id,)
-        location_dest_id = (self.env.ref("stock.stock_location_stock").id,)
-        components = self.pack_dc.pack_line_ids.mapped("product_id")
-        partner = self.env["res.partner"].create({"name": "Test Partner"})
-
-        picking = self.env["stock.picking"].create(
-            {
-                "partner_id": partner.id,
-                "picking_type_id": self.env.ref("stock.picking_type_in").id,
-                "location_id": location_id,
-                "location_dest_id": location_dest_id,
-                "move_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "product_id": components[0].id,
-                            "product_uom_qty": 5,
-                            "location_id": location_id,
-                            "location_dest_id": location_dest_id,
-                        },
-                    ),
-                    (
-                        0,
-                        0,
-                        {
-                            "product_id": components[1].id,
-                            "product_uom_qty": 7,
-                            "location_id": location_id,
-                            "location_dest_id": location_dest_id,
-                        },
-                    ),
-                    (
-                        0,
-                        0,
-                        {
-                            "product_id": components[3].id,
-                            "product_uom_qty": 9,
-                            "location_id": location_id,
-                            "location_dest_id": location_dest_id,
-                        },
-                    ),
-                ],
-            }
-        )
+        moves_data = [
+            (self.component_1, 5),
+            (self.component_2, 7),
+            (self.component_4, 9),
+        ]
+        picking = self._create_picking(self.warehouse.in_type_id.id, moves_data)
         picking.action_confirm()
         self.assertEqual(self.pack_dc.virtual_available, 5)
         self.assertEqual(self.pack_dc.qty_available, 0)
-        wizard_dict = picking.button_validate()
-        if wizard_dict is not True:
-            wizard = Form(
-                self.env[(wizard_dict.get("res_model"))].with_context(
-                    **wizard_dict["context"]
-                )
-            ).save()
-            wizard.process()
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
         self.assertEqual(self.pack_dc.virtual_available, 5)
         self.assertEqual(self.pack_dc.qty_available, 5)
 
@@ -217,7 +157,7 @@ class TestStockProductPack(TransactionCase):
             self.pack_dc_with_dm,
             10,
             155,
-            self.env.ref("stock.stock_location_stock"),
+            self.warehouse.lot_stock_id,
         )
         # Check that no moves were created for the pack product itself
         # Only components should have moves created


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/product-pack/pull/259

Related to https://github.com/OCA/product-pack/pull/258

Display Delivery Slip data correctly in pack products

Changes done
- [x] `stock_product_pack`: Filter the warehouse correctly by company]
- [x] `product_pack`: Change TransactionCase to BaseCommon
- [x] `stock_product_pack`: Improve tests
- [x] `stock_product_pack`: Display Delivery Slip data correctly sorted in pack products
- [x] `sale_stock_product_pack`: Display the grouped data correctly on the delivery slip
- [x] `stock_product_pack`: Change maintainer

Please @pedrobaeza and @eduezerouali-tecnativa can you review it?

@Tecnativa TT62930 TT62189