### PR TITLE
[FIX] stock_product_pack: don't skip non detailed packs on dont_create_move

### DIFF
--- a/sale_stock_product_pack/models/sale_order.py
+++ b/sale_stock_product_pack/models/sale_order.py
@@ -1,12 +1,25 @@
 # Copyright 2021 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # pylint: disable=W8110
-from odoo import models
+from odoo import api, models
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    # Same depends sale_stock declares for qty_delivered [1], just one hop
+    # further through the components: a pack line's own qty_delivered is
+    # derived from its children's qty_delivered below, so it must be
+    # invalidated/recomputed whenever a child's own moves change (e.g. a
+    # return), not only when the pack line's own moves do.
+    # [1] https://github.com/odoo/odoo/blob/19.0/addons/sale_stock/models/
+    #     sale_order_line.py -> SaleOrderLine._compute_qty_delivered
+    @api.depends(
+        "pack_child_line_ids.move_ids.state",
+        "pack_child_line_ids.move_ids.location_dest_usage",
+        "pack_child_line_ids.move_ids.quantity",
+        "pack_child_line_ids.move_ids.product_uom",
+    )
     def _compute_qty_delivered(self):
         """Compute pack delivered pack quantites according to its components
         deliveries"""

--- a/sale_stock_product_pack/tests/test_sale_stock_product_pack.py
+++ b/sale_stock_product_pack/tests/test_sale_stock_product_pack.py
@@ -136,3 +136,162 @@ class TestSaleStockProductPack(TestSaleProductPackBase):
         )
         self.assertEqual(line_pack_component2_data["qty_ordered"], 2)
         self.assertEqual(line_pack_component2_data["quantity"], 2)
+
+    def test_dont_create_move_non_detailed_pack(self):
+        """A 'Non Detailed' pack with 'dont_create_move' active must not
+        generate a stock.move for the parent product either.
+        Regression test for stock_rule.run(), which used to only skip the
+        parent procurement when pack_type == 'detailed', silently ignoring
+        the flag for non detailed packs.
+
+        qty_delivered is left untouched: it stays driven by real stock
+        moves, so a pack that moves nothing is simply not delivered. Such a
+        pack shouldn't be invoiced on delivery in the first place -- that
+        is what invoice_policy is for.
+        """
+        self.pack.write(
+            {
+                "pack_type": "non_detailed",
+                "dont_create_move": True,
+            }
+        )
+        pack_line = self._add_so_line()
+        self.sale = self.sale_order
+        self.sale.action_confirm()
+        self.assertFalse(
+            self.sale.picking_ids.move_ids.filtered(
+                lambda move: move.product_id == self.pack
+            ),
+            "The pack product must not generate a stock.move when "
+            "'dont_create_move' is active, regardless of its pack display "
+            "type.",
+        )
+        self.assertEqual(
+            pack_line.qty_delivered,
+            0.0,
+            "Confirming the order must not mark the pack as delivered: "
+            "qty_delivered has to reflect real stock moves only.",
+        )
+
+    def test_enabling_dont_create_move_keeps_delivery_history(self):
+        """Enabling 'dont_create_move' on a product must not rewrite the
+        delivered quantity of orders that were already (partially)
+        delivered.
+
+        Regression test for the scenario reported in review: sell 4 packs
+        with the flag disabled, deliver 2, then enable the flag ->
+        qty_delivered used to jump from 2 to 4, altering delivery history
+        and risking over-invoicing.
+        """
+        self.pack.pack_type = "non_detailed"
+        pack_line = self._add_so_line()
+        pack_line.product_uom_qty = 4
+        self.sale_order.action_confirm()
+        # Deliver 2 out of the 4 ordered packs.
+        pack_move = self.sale_order.picking_ids.move_ids.filtered(
+            lambda move: move.product_id == self.pack
+        )
+        self.assertTrue(pack_move, "The pack should move while the flag is off.")
+        pack_move.quantity = 2
+        pack_move.picked = True
+        pack_move.picking_id._action_done()
+        self.assertEqual(pack_line.qty_delivered, 2.0)
+
+        self.pack.dont_create_move = True
+
+        self.assertEqual(
+            pack_line.qty_delivered,
+            2.0,
+            "Enabling 'dont_create_move' must not restate what was already delivered.",
+        )
+
+    def _create_return_moves(self, delivery_moves, qty_by_product):
+        # Return moves are created directly via the ORM (state='done',
+        # to_refund=True) instead of going through stock.picking /
+        # stock.return.picking: that orchestration depends on the
+        # warehouse's delivery route (one-step vs multi-step) and on
+        # enterprise overrides (e.g. helpdesk_stock redeclares the wizard's
+        # 'picking_id' as a computed field with unrelated resolution
+        # logic), both of which make it fragile and environment-dependent
+        # for a unit test. This mirrors exactly the fields
+        # _compute_qty_delivered's filter looks at.
+        return_picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": delivery_moves[:1].picking_id.picking_type_id.id,
+                "location_id": delivery_moves[:1].location_dest_id.id,
+                "location_dest_id": delivery_moves[:1].location_id.id,
+            }
+        )
+        for move in delivery_moves:
+            qty = qty_by_product.get(move.product_id, 0.0)
+            if not qty:
+                continue
+            self.env["stock.move"].create(
+                {
+                    "product_id": move.product_id.id,
+                    "product_uom_qty": qty,
+                    "quantity": qty,
+                    "product_uom": move.product_uom.id,
+                    "picking_id": return_picking.id,
+                    "location_id": move.location_dest_id.id,
+                    "location_dest_id": move.location_id.id,
+                    "sale_line_id": move.sale_line_id.id,
+                    "origin_returned_move_id": move.id,
+                    "to_refund": True,
+                    "state": "done",
+                    "picked": True,
+                }
+            )
+        return return_picking
+
+    def test_qty_delivered_pack_after_component_return(self):
+        """A detailed pack's own qty_delivered must drop when its
+        components are returned, without any manual/forced recompute.
+
+        Regression test for the missing @api.depends on
+        _compute_qty_delivered: it derives the pack line's qty_delivered
+        from its children's qty_delivered, but only depended on the pack
+        line's own (untouched) stock moves, so returning the components
+        never invalidated the cached value on the parent.
+        """
+        self.pack.pack_type = "detailed"
+        self.component1.is_storable = True
+        self.component2.is_storable = True
+        pack_line = self._add_so_line(self.pack)
+        pack_line.product_uom_qty = 2
+        self._create_stock_quant(self.component1, 10)
+        self._create_stock_quant(self.component2, 10)
+        # Some Adhoc-only modules (sale_exception, not a dependency of this
+        # OCA module) can silently turn action_confirm() into a no-op (it
+        # returns a popup action instead of confirming) for a partner/order
+        # that trips an exception rule, e.g. an unapproved partner. Mirror
+        # the "Ignore Exceptions" checkbox so this test isn't at the mercy
+        # of whatever exception rules happen to be configured wherever it
+        # runs.
+        if "ignore_exception" in self.sale_order._fields:
+            self.sale_order.ignore_exception = True
+        self.sale_order.action_confirm()
+        self.assertEqual(
+            self.sale_order.state, "sale", "action_confirm did not confirm the order."
+        )
+        picking = self.sale_order.picking_ids
+        picking.button_validate()
+        self.assertEqual(
+            picking.state,
+            "done",
+            "Delivery picking did not complete (button_validate likely "
+            "returned a wizard action instead of validating directly).",
+        )
+
+        self.assertEqual(pack_line.qty_delivered, 2.0)
+
+        # Return exactly 1 pack's worth of both components (proportional).
+        delivery_moves = picking.move_ids.filtered(lambda m: m.state == "done")
+        self.assertTrue(delivery_moves, "No completed delivery moves found to return.")
+        self._create_return_moves(
+            delivery_moves, {self.component1: 2.0, self.component2: 1.0}
+        )
+
+        # No explicit invalidate/recompute call here: this must reflect the
+        # return through normal field dependency tracking alone.
+        self.assertEqual(pack_line.qty_delivered, 1.0)

--- a/stock_product_pack/models/stock_rule.py
+++ b/stock_product_pack/models/stock_rule.py
@@ -8,16 +8,18 @@ class StockRule(models.Model):
 
     @api.model
     def run(self, procurements, raise_user_error=True):
-        """If 'run' is called on a pack product storable.
-        we remove the procurement with this product pack.
+        """If 'run' is called on a pack product storable with
+        'dont_create_move' active, we remove the procurement with this
+        product pack, regardless of its pack display type (detailed or
+        non detailed).
         """
-        for procurement in procurements:
-            if (
+        procurements = [
+            procurement
+            for procurement in procurements
+            if not (
                 procurement.product_id
                 and procurement.product_id.pack_ok
                 and procurement.product_id.dont_create_move
-                and procurement.product_id.pack_type == "detailed"
-            ):
-                procurements.remove(procurement)
-
+            )
+        ]
         return super().run(procurements, raise_user_error=raise_user_error)


### PR DESCRIPTION
## Summary

`stock.rule.run()` only removed the parent pack's procurement (so it doesn't create its own `stock.move`) when `pack_type == "detailed"`. A **non detailed** pack with `dont_create_move` active kept generating a `stock.move` for the parent product in the delivery, defeating the purpose of the flag.

Additionally, `_compute_qty_delivered` derives a pack line's own `qty_delivered` from its components, but only depended on the pack line's **own** (untouched) stock moves — so returning a pack's components never invalidated the cached value on the parent, leaving it stale.

## Change

- **`stock_product_pack/models/stock_rule.py`**: the exclusion now depends only on `pack_ok` + `dont_create_move`, applying to both `detailed` and `non_detailed` packs. Also avoids mutating the `procurements` list while iterating over it (the previous `for ... procurements.remove(...)` pattern could skip elements).
- **`sale_stock_product_pack/models/sale_order.py`**: added the same `@api.depends` `sale_stock` declares for `qty_delivered`, one hop further through the components, so a pack's delivered quantity is correctly recomputed when its components are returned.

`qty_delivered` is deliberately left driven by real stock moves only. A non detailed pack that moves nothing stays at `Delivered = 0`: such a pack shouldn't be invoiced on delivery in the first place — that is what `invoice_policy` is for. (This contradicts `dont_create_move`'s current help text, which promises the pack is "set as delivered upon sale confirmation"; see the discussion below.)

## Test plan

- `test_dont_create_move_non_detailed_pack`: confirms an order with a non detailed pack (`dont_create_move=True`), asserts the delivery has no `stock.move` for the pack product and that `qty_delivered` stays at 0.
- `test_enabling_dont_create_move_keeps_delivery_history`: sells 4 packs with the flag off, delivers 2, then enables the flag — asserts the delivered quantity is not restated.
- `test_qty_delivered_pack_after_component_return`: sells 2 detailed packs, delivers, returns exactly 1 pack's worth of both components proportionally, asserts `qty_delivered` drops accordingly without any manual recompute.
- All three verified to fail against the code before their respective fix.
- Full `product_pack` / `sale_product_pack` / `stock_product_pack` / `sale_stock_product_pack` suites pass: **29 tests, 0 failures**.