### PR TITLE
[18.0][IMP] product_pack: archive pack lines when their product is archived

### DIFF
--- a/product_pack/models/product_pack_line.py
+++ b/product_pack/models/product_pack_line.py
@@ -29,6 +29,17 @@ class ProductPackLine(models.Model):
         index=True,
         required=True,
     )
+    active = fields.Boolean(
+        compute="_compute_active",
+        store=True,
+        readonly=True,
+        help="Inactive when the parent or component product is archived.",
+    )
+
+    @api.depends("parent_product_id.active", "product_id.active")
+    def _compute_active(self):
+        for line in self:
+            line.active = line.parent_product_id.active and line.product_id.active
 
     # because on expand_pack_line we are searching for existing product, we
     # need to enforce this condition

--- a/product_pack/tests/test_product_pack.py
+++ b/product_pack/tests/test_product_pack.py
@@ -95,3 +95,25 @@ class TestProductPack(ProductPackCommon):
             pricelist=self.discount_pricelist.id
         )._get_contextual_price()
         self.assertEqual(price, 63)  # 70 with 10% discount
+
+    def test_pack_line_active_matches_products(self):
+        """Pack line active state follows parent and component product states."""
+        self.assertTrue(self.pack_line1.active)
+
+        self.component1.active = False
+        self.assertFalse(self.pack_line1.active)
+
+        self.component1.active = True
+        self.assertTrue(self.pack_line1.active)
+
+        self.pack.active = False
+        self.assertFalse(self.pack_line1.active)
+
+        self.pack.active = True
+        self.assertTrue(self.pack_line1.active)
+
+    def test_archived_pack_line_excluded_from_pack_lines(self):
+        """Archived pack lines are not returned by default pack_line_ids."""
+        self.component2.active = False
+        self.assertNotIn(self.component2, self.pack.pack_line_ids.product_id)
+        self.assertIn(self.component1, self.pack.pack_line_ids.product_id)


### PR DESCRIPTION
This PR adds an \active\ field on \product.pack.line\ that is stored, readonly, and computed from both the parent pack product and the component product.

When a product is archived, its pack lines become inactive automatically. Because Odoo applies the standard active test on One2many relations, archived components no longer appear in \product.pack_line_ids\ unless inactive records are explicitly requested.

This fixes the common issue where archived products continue to show up in reports, sale orders, or any other place that lists the contents of a pack.

**Changes:**
- Add computed stored \active\ field on \product.pack.line\.
- Add tests covering component and parent product archival.

**Use case:**
A product that is no longer sold/manufactured is archived, but it is still referenced as a component in existing packs. Without this change it keeps appearing in pack listings.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr