### PR TITLE
[18.0][IMP] sale_product_pack: add index to pack_parent_line_id field

### DIFF
--- a/sale_product_pack/models/sale_order_line.py
+++ b/sale_product_pack/models/sale_order_line.py
@@ -24,6 +24,7 @@ class SaleOrderLine(models.Model):
         "sale.order.line",
         "Pack",
         help="The pack that contains this product.",
+        index=True,
     )
     pack_child_line_ids = fields.One2many(
         "sale.order.line", "pack_parent_line_id", "Lines in pack"


### PR DESCRIPTION
Improve performance on queries filtering by pack_parent_line_id.
This field is used frequently in filtered() operations and as inverse
for One2many relations.