### PR TITLE
[17.0][FIX] sale_product_pack: add missing index on pack_parent_line_id

### DIFF
--- a/sale_product_pack/models/sale_order_line.py
+++ b/sale_product_pack/models/sale_order_line.py
@@ -24,6 +24,7 @@ class SaleOrderLine(models.Model):
         "sale.order.line",
         "Pack",
         help="The pack that contains this product.",
+        index=True,
     )
     pack_child_line_ids = fields.One2many(
         "sale.order.line", "pack_parent_line_id", "Lines in pack"


### PR DESCRIPTION
Without an index, pack_child_line_ids (the inverse one2many) forces a full sequential scan on sale_order_line whenever a pack line is written (product_id/product_uom_qty), which is very costly on tables with millions of rows.