### PR TITLE
[19.0][FIX] sale_product_pack: watch tax_ids in check_pack_line_modify

### DIFF
--- a/sale_product_pack/models/sale_order_line.py
+++ b/sale_product_pack/models/sale_order_line.py
@@ -107,7 +107,7 @@ class SaleOrderLine(models.Model):
         "price_unit",
         "discount",
         "name",
-        "tax_id",
+        "tax_ids",
     )
     def check_pack_line_modify(self):
         """Do not let to edit a sale order line if this one belongs to pack"""


### PR DESCRIPTION
The tax_id field no longer exists.