### PR TITLE
[18.0][FIX] product_pack: totalize pack price in _get_product_price_rule

### DIFF
--- a/product_pack/models/product_pricelist.py
+++ b/product_pack/models/product_pricelist.py
@@ -11,7 +11,9 @@ class Pricelist(models.Model):
                   considering pricelist rules
         """
         self and self.ensure_one()
-        if product._is_pack_to_be_handled():
+        if product._is_pack_to_be_handled() and not self.env.context.get(
+            "pack_base_price_only"
+        ):
             # NOTE: This exception is to avoid adding the list price of the packs
             # "totalized" and "non detailed". Should be removed to solve the issue #169.
             if (
@@ -20,15 +22,38 @@ class Pricelist(models.Model):
             ):
                 pack_price = 0
             else:
-                pack_price = self._compute_price_rule(product, *args, **kwargs)[
-                    product.id
-                ][0]
+                # A rule based on another pricelist resolves through this same
+                # method, so ask for the pack's own price to avoid totalizing twice.
+                pack_price = self.with_context(
+                    pack_base_price_only=True
+                )._compute_price_rule(product, *args, **kwargs)[product.id][0]
 
             for line in product.sudo().pack_line_ids:
                 pack_price += line._get_pack_line_price(self, *args, **kwargs)
             return pack_price
         else:
             return super()._get_product_price(product, *args, **kwargs)
+
+    def _get_product_price_rule(self, product, *args, **kwargs):
+        """Compute the pricelist price & rule for the specified pack product.
+
+        The pack price is built from its components, so the bare pricelist rule
+        price is not the pack price. The e-commerce product page and shop listing
+        (`website_sale`) and the product configurator reach the price through this
+        method, not through `_get_product_price`.
+
+        No single rule explains a pack price, so none is reported: applying the
+        returned rule to the pack alone yields an unrelated price, which the shop
+        would render as a discount that does not exist.
+
+        :returns: (unit price of the pack product + components, False)
+        """
+        self and self.ensure_one()
+        if product._is_pack_to_be_handled() and not self.env.context.get(
+            "pack_base_price_only"
+        ):
+            return self._get_product_price(product, *args, **kwargs), False
+        return super()._get_product_price_rule(product, *args, **kwargs)
 
     def _get_products_price(self, products, *args, **kwargs):
         """Compute the pricelist price for the specified pack product, qty & uom.

--- a/product_pack/tests/test_product_pack.py
+++ b/product_pack/tests/test_product_pack.py
@@ -95,3 +95,57 @@ class TestProductPack(ProductPackCommon):
             pricelist=self.discount_pricelist.id
         )._get_contextual_price()
         self.assertEqual(price, 63)  # 70 with 10% discount
+
+    def test_pack_price_rule_totalized(self):
+        """`_get_product_price_rule` must totalize components, as the e-commerce
+        and the sales catalog build their prices with it."""
+        self.pack.pack_component_price = "totalized"
+        price, rule_id = self.discount_pricelist._get_product_price_rule(self.pack, 1.0)
+        self.assertEqual(price, 63)  # 70 with 10% discount
+        self.assertFalse(rule_id)  # no single rule explains a pack price
+
+    def test_pack_price_rule_detailed(self):
+        price, rule_id = self.discount_pricelist._get_product_price_rule(
+            self.pack.with_context(whole_pack_price=True), 1.0
+        )
+        self.assertEqual(price, 72)  # 80 (10 + 70) with 10% discount
+        self.assertFalse(rule_id)  # no single rule explains a pack price
+
+    def test_pack_price_rule_ignored(self):
+        """Not a pack to be handled: the pack's own price is used."""
+        self.pack.pack_component_price = "ignored"
+        price, rule_id = self.discount_pricelist._get_product_price_rule(self.pack, 1.0)
+        self.assertEqual(price, 9)  # 10 with 10% discount
+        self.assertEqual(rule_id, self.discount_pricelist.item_ids.id)
+
+    def test_price_rule_no_pack(self):
+        """Regular products must keep the standard behaviour."""
+        price, rule_id = self.discount_pricelist._get_product_price_rule(
+            self.component1, 1.0
+        )
+        self.assertEqual(price, 18)  # 20 with 10% discount
+        self.assertEqual(rule_id, self.discount_pricelist.item_ids.id)
+
+    def test_pack_price_rule_based_on_other_pricelist(self):
+        """A pricelist based on another one must not add the components twice."""
+        derived_pricelist = self.env["product.pricelist"].create(
+            {
+                "name": "Based on Discount",
+                "company_id": self.env.company.id,
+                "item_ids": [
+                    Command.create(
+                        {
+                            "applied_on": "3_global",
+                            "base": "pricelist",
+                            "base_pricelist_id": self.discount_pricelist.id,
+                            "compute_price": "formula",
+                            "price_discount": 0,
+                        },
+                    )
+                ],
+            }
+        )
+        price, __ = derived_pricelist._get_product_price_rule(
+            self.pack.with_context(whole_pack_price=True), 1.0
+        )
+        self.assertEqual(price, 72)  # 80 (10 + 70) with 10% discount, once


### PR DESCRIPTION
## Problem

`product_pack` overrides `_get_product_price` and `_get_products_price` on
`product.pricelist`, but not `_get_product_price_rule`. Since `product`'s three
methods all delegate to the same `_compute_price_rule`, the un-overridden one
returns the pack's own list price instead of the components total.

`website_sale._get_additionnal_combination_info` and
`sale.product.template._get_configurator_display_price` reach the price through
`_get_product_price_rule`, so a pack with `pack_type=detailed` and
`pack_component_price=totalized` is published in the e-commerce at its raw list
price -- on the product page and on the shop listing -- while the sale order
computes the correct total. In that mode the pack's own price is meant to be
ignored (`_get_product_price` starts the sum at 0), so whatever value it holds
leaks straight to the shop.

A second, pre-existing issue surfaces once the pack price is totalized here: a
pricelist rule with `base='pricelist'` resolves through `_get_product_price`
again, which adds the components a second time. That doubling is reachable today
in the backend as well.

## Fix

* Override `_get_product_price_rule` so packs return the totalized price.
* Report **no rule** (`False`) for packs. A pack price is built from its
  components, so applying the matched rule to the pack alone yields an unrelated
  price -- `_compute_price_before_discount` would return the pack's raw
  `list_price` and the shop would render a discount that does not exist. Core
  documents `int or False` for that slot and `_show_discount_on_shop` already
  handles an empty rule. Consequence: packs no longer show a struck-through
  price on the shop, instead of showing an incoherent one.
* Guard the recursive base-price resolution with the existing
  `pack_base_price_only` context key, so a rule based on another pricelist does
  not totalize twice.

## Test plan

Five new tests in `product_pack/tests/test_product_pack.py` covering
`_get_product_price_rule` for `totalized`, `detailed` (with `whole_pack_price`),
`ignored`, a non-pack product, and a pricelist based on another pricelist.

Without the fix, the `totalized` and `detailed` cases fail with `9.0 != 63` and
`9.0 != 72` (the pack's own price with the pricelist discount applied).

Checked on 18.0: 40 tests green across `product_pack`, `purchase_product_pack`,
`sale_product_pack`, `sale_stock_product_pack` and `stock_product_pack`.
End to end on a shop, a `totalized` pack whose components total 2662.5 now
publishes 2662.5 on both the product page and the listing, matching the sale
order, and shows no bogus discount when a percentage rule applies.